### PR TITLE
Fix tab switching: reconnect CDP client to new target

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -105,6 +105,32 @@ export async function evaluateAsync(expression) {
   return evaluate(expression, { awaitPromise: true });
 }
 
+export async function connectToTarget(targetId) {
+  // Close existing connection if any
+  if (client) {
+    try { await client.close(); } catch {}
+    client = null;
+    targetInfo = null;
+  }
+
+  // Look up target info from the target list
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const target = targets.find(t => t.id === targetId);
+  if (!target) {
+    throw new Error(`Target ${targetId} not found in CDP target list`);
+  }
+
+  targetInfo = target;
+  client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: targetId });
+
+  await client.Runtime.enable();
+  await client.Page.enable();
+  await client.DOM.enable();
+
+  return client;
+}
+
 export async function disconnect() {
   if (client) {
     try { await client.close(); } catch {}

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,7 +2,7 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
+import { getClient, evaluate, connectToTarget } from '../connection.js';
 
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
@@ -49,8 +49,13 @@ export async function newTab() {
 
   await new Promise(r => setTimeout(r, 2000));
 
-  // Verify a new tab appeared
+  // Verify a new tab appeared and connect to the new tab
   const state = await list();
+  if (state.tabs.length > 0) {
+    // The newest tab is typically the last one in the list
+    const newTarget = state.tabs[state.tabs.length - 1];
+    await connectToTarget(newTarget.id);
+  }
   return { success: true, action: 'new_tab_opened', ...state };
 }
 
@@ -99,6 +104,10 @@ export async function switchTab({ index }) {
   try {
     const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
     const text = await resp.text();
+
+    // Reconnect CDP client to the newly activated target
+    await connectToTarget(target.id);
+
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {
     throw new Error(`Failed to activate tab ${idx}: ${e.message}`);

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -154,6 +154,46 @@ export async function newTab({ type, name } = {}) {
 }
 
 /**
+ * Dismiss the "unsaved changes" dialog if it appears.
+ * Checks both the shell and all chart targets since the dialog
+ * can render in either context.
+ */
+async function dismissUnsavedDialog() {
+  const CDP_mod = (await import('chrome-remote-interface')).default;
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  const pages = targets.filter(t => t.type === 'page');
+
+  for (const target of pages) {
+    let client;
+    try {
+      client = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+      await client.Runtime.enable();
+      const { result } = await client.Runtime.evaluate({
+        expression: `
+          (() => {
+            const buttons = document.querySelectorAll('button');
+            for (const btn of buttons) {
+              if (/close without saving/i.test(btn.textContent)) {
+                btn.click();
+                return 'dismissed';
+              }
+            }
+            return 'not found';
+          })()
+        `,
+        returnByValue: true,
+      });
+      await client.close();
+      if (result.value === 'dismissed') return 'dismissed';
+    } catch {
+      if (client) try { await client.close(); } catch {}
+    }
+  }
+  return 'no dialog';
+}
+
+/**
  * Close the active tab via the Electron shell's close button.
  */
 export async function closeTab() {
@@ -180,21 +220,32 @@ export async function closeTab() {
         const closeBtn = activeTab.querySelector('.tab-close-button-container button');
         if (!closeBtn) return 'no close button';
         closeBtn.click();
-        return 'closed';
+        return 'clicked';
       })()
     `,
     returnByValue: true,
   });
   await shellClient.close();
 
-  if (result.value !== 'closed') {
+  if (result.value !== 'clicked') {
     throw new Error(`Failed to close tab: ${result.value}`);
   }
 
-  await new Promise(r => setTimeout(r, 1000));
+  // Wait briefly then dismiss "unsaved changes" dialog if it appears
+  await new Promise(r => setTimeout(r, 500));
+  await dismissUnsavedDialog();
+
+  // Poll until the tab count actually decreases or timeout
+  let after;
+  for (let i = 0; i < 10; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    after = await list();
+    if (after.tab_count < before.tab_count) break;
+    // Dialog may have reappeared or not been found yet — retry dismiss
+    await dismissUnsavedDialog();
+  }
 
   // Reconnect to the first available chart tab
-  const after = await list();
   if (after.tabs.length > 0) {
     await connectToTarget(after.tabs[0].id);
   }

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -155,39 +155,44 @@ export async function newTab({ type, name } = {}) {
 
 /**
  * Dismiss the "unsaved changes" dialog if it appears.
- * Checks both the shell and all chart targets since the dialog
- * can render in either context.
+ * The dialog spawns as a separate Electron window (new CDP target)
+ * that may take a moment to appear in the target list.
+ * Polls for up to 3 seconds, then gives up (no dialog = no unsaved changes).
  */
 async function dismissUnsavedDialog() {
   const CDP_mod = (await import('chrome-remote-interface')).default;
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
-  const targets = await resp.json();
-  const pages = targets.filter(t => t.type === 'page');
 
-  for (const target of pages) {
-    let client;
-    try {
-      client = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: target.id });
-      await client.Runtime.enable();
-      const { result } = await client.Runtime.evaluate({
-        expression: `
-          (() => {
-            const buttons = document.querySelectorAll('button');
-            for (const btn of buttons) {
-              if (/close without saving/i.test(btn.textContent)) {
-                btn.click();
-                return 'dismissed';
+  for (let attempt = 0; attempt < 6; attempt++) {
+    await new Promise(r => setTimeout(r, 500));
+    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+    const targets = await resp.json();
+    const pages = targets.filter(t => t.type === 'page');
+
+    for (const target of pages) {
+      let client;
+      try {
+        client = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+        await client.Runtime.enable();
+        const { result } = await client.Runtime.evaluate({
+          expression: `
+            (() => {
+              const buttons = document.querySelectorAll('button');
+              for (const btn of buttons) {
+                if (/close without saving/i.test(btn.textContent)) {
+                  btn.click();
+                  return 'dismissed';
+                }
               }
-            }
-            return 'not found';
-          })()
-        `,
-        returnByValue: true,
-      });
-      await client.close();
-      if (result.value === 'dismissed') return 'dismissed';
-    } catch {
-      if (client) try { await client.close(); } catch {}
+              return 'not found';
+            })()
+          `,
+          returnByValue: true,
+        });
+        await client.close();
+        if (result.value === 'dismissed') return 'dismissed';
+      } catch {
+        if (client) try { await client.close(); } catch {}
+      }
     }
   }
   return 'no dialog';
@@ -231,18 +236,15 @@ export async function closeTab() {
     throw new Error(`Failed to close tab: ${result.value}`);
   }
 
-  // Wait briefly then dismiss "unsaved changes" dialog if it appears
-  await new Promise(r => setTimeout(r, 500));
+  // Dismiss "unsaved changes" dialog if it appears (polls for up to 3s)
   await dismissUnsavedDialog();
 
-  // Poll until the tab count actually decreases or timeout
+  // Wait for the tab to actually close
   let after;
   for (let i = 0; i < 10; i++) {
     await new Promise(r => setTimeout(r, 500));
     after = await list();
     if (after.tab_count < before.tab_count) break;
-    // Dialog may have reappeared or not been found yet — retry dismiss
-    await dismissUnsavedDialog();
   }
 
   // Reconnect to the first available chart tab

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -166,12 +166,19 @@ async function dismissUnsavedDialog() {
     await new Promise(r => setTimeout(r, 500));
     const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
     const targets = await resp.json();
-    const pages = targets.filter(t => t.type === 'page');
+    // Only check file:// targets (dialog is an Electron window) and skip empty URLs
+    const candidates = targets.filter(t =>
+      t.type === 'page' && t.url && t.url.length > 0 && /^file:\/\//i.test(t.url)
+    );
 
-    for (const target of pages) {
+    for (const target of candidates) {
       let client;
       try {
-        client = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+        // Use a timeout to avoid hanging on unresponsive targets
+        client = await Promise.race([
+          CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: target.id }),
+          new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 2000)),
+        ]);
         await client.Runtime.enable();
         const { result } = await client.Runtime.evaluate({
           expression: `

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -28,39 +28,133 @@ export async function list() {
 }
 
 /**
- * Open a new chart tab via keyboard shortcut (Ctrl+T / Cmd+T).
+ * Find the Electron shell target that contains the tab bar.
  */
-export async function newTab() {
-  const c = await getClient();
-
-  // Electron/TradingView Desktop uses Ctrl+T for new tab on macOS too
-  // But some versions use Cmd+T
-  const isMac = process.platform === 'darwin';
-  const mod = isMac ? 4 : 2; // 4 = meta (Cmd), 2 = ctrl
-
-  await c.Input.dispatchKeyEvent({
-    type: 'keyDown',
-    modifiers: mod,
-    key: 't',
-    code: 'KeyT',
-    windowsVirtualKeyCode: 84,
-  });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 't', code: 'KeyT' });
-
-  await new Promise(r => setTimeout(r, 2000));
-
-  // Verify a new tab appeared and connect to the new tab
-  const state = await list();
-  if (state.tabs.length > 0) {
-    // The newest tab is typically the last one in the list
-    const newTarget = state.tabs[state.tabs.length - 1];
-    await connectToTarget(newTarget.id);
+async function findShellTarget() {
+  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const targets = await resp.json();
+  // The shell target is a file:// URL containing the tab bar with .create-new-tab-button
+  const shells = targets.filter(t =>
+    t.type === 'page' && /^file:\/\/\//i.test(t.url) && /windowsapps|resources/i.test(t.url)
+  );
+  // The shell with the tab bar has the .create-new-tab-button — try each
+  const CDP_mod = (await import('chrome-remote-interface')).default;
+  for (const shell of shells) {
+    let client;
+    try {
+      client = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: shell.id });
+      await client.Runtime.enable();
+      const { result } = await client.Runtime.evaluate({
+        expression: `!!document.querySelector('.create-new-tab-button')`,
+        returnByValue: true,
+      });
+      await client.close();
+      if (result.value) return shell;
+    } catch {
+      if (client) try { await client.close(); } catch {}
+    }
   }
-  return { success: true, action: 'new_tab_opened', ...state };
+  return null;
 }
 
 /**
- * Close the current tab via keyboard shortcut (Ctrl+W / Cmd+W).
+ * Open a new tab via the Electron shell's tab bar button.
+ * @param {object} opts
+ * @param {string} [opts.type] - Tab type to open (currently: "layout")
+ * @param {string} [opts.name] - Name of the item to select (e.g. layout name)
+ */
+export async function newTab({ type, name } = {}) {
+  const chartsBefore = await list();
+
+  // Step 1: Find the Electron shell and click the new tab button
+  const shell = await findShellTarget();
+  if (!shell) {
+    throw new Error('Could not find TradingView Electron shell target. Is TradingView Desktop running?');
+  }
+
+  const CDP_mod = (await import('chrome-remote-interface')).default;
+  const shellClient = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: shell.id });
+  await shellClient.Runtime.enable();
+  await shellClient.Runtime.evaluate({
+    expression: `document.querySelector('.create-new-tab-button').click()`,
+    returnByValue: true,
+  });
+  await shellClient.close();
+
+  // Step 2: Wait for the new-tab selection screen target to appear
+  let newTabTarget = null;
+  for (let i = 0; i < 15; i++) {
+    await new Promise(r => setTimeout(r, 500));
+    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+    const targets = await resp.json();
+    newTabTarget = targets.find(t => t.type === 'page' && /new-tab/i.test(t.url));
+    if (newTabTarget) break;
+  }
+
+  if (!newTabTarget) {
+    throw new Error('New tab opened but selection screen target not found after 7.5 seconds');
+  }
+
+  // Step 3: If type specified, select the item on the selection screen
+  if (type === 'layout' && name) {
+    const tabClient = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: newTabTarget.id });
+    await tabClient.Runtime.enable();
+
+    // Wait for layout list to render
+    let clicked = false;
+    for (let i = 0; i < 10; i++) {
+      const { result } = await tabClient.Runtime.evaluate({
+        expression: `
+          (() => {
+            const items = document.querySelectorAll('.layout-list-item');
+            for (const item of items) {
+              if (item.textContent.includes('${name.replace(/'/g, "\\'")}')) {
+                item.click();
+                return true;
+              }
+            }
+            return false;
+          })()
+        `,
+        returnByValue: true,
+      });
+      if (result.value) { clicked = true; break; }
+      await new Promise(r => setTimeout(r, 500));
+    }
+    await tabClient.close();
+
+    if (!clicked) {
+      throw new Error(`Layout "${name}" not found on the new tab selection screen`);
+    }
+
+    // Wait for the chart target to appear
+    let chartTarget = null;
+    for (let i = 0; i < 15; i++) {
+      await new Promise(r => setTimeout(r, 500));
+      const chartsAfter = await list();
+      // Find the new chart target that wasn't in the before list
+      const beforeIds = new Set(chartsBefore.tabs.map(t => t.id));
+      const newChart = chartsAfter.tabs.find(t => !beforeIds.has(t.id));
+      if (newChart) { chartTarget = newChart; break; }
+    }
+
+    if (chartTarget) {
+      await connectToTarget(chartTarget.id);
+      const state = await list();
+      return { success: true, action: 'new_tab_opened', type: 'layout', name, tab_id: chartTarget.id, ...state };
+    } else {
+      throw new Error(`Layout "${name}" was selected but chart target did not appear after 7.5 seconds`);
+    }
+  }
+
+  // No type specified — stay on selection screen, connect to it
+  await connectToTarget(newTabTarget.id);
+  const state = await list();
+  return { success: true, action: 'new_tab_opened', type: 'selection_screen', ...state };
+}
+
+/**
+ * Close the active tab via the Electron shell's close button.
  */
 export async function closeTab() {
   const before = await list();
@@ -68,22 +162,43 @@ export async function closeTab() {
     throw new Error('Cannot close the last tab. Use tv_launch to restart TradingView instead.');
   }
 
-  const c = await getClient();
-  const isMac = process.platform === 'darwin';
-  const mod = isMac ? 4 : 2;
+  const shell = await findShellTarget();
+  if (!shell) {
+    throw new Error('Could not find TradingView Electron shell target.');
+  }
 
-  await c.Input.dispatchKeyEvent({
-    type: 'keyDown',
-    modifiers: mod,
-    key: 'w',
-    code: 'KeyW',
-    windowsVirtualKeyCode: 87,
+  const CDP_mod = (await import('chrome-remote-interface')).default;
+  const shellClient = await CDP_mod({ host: CDP_HOST, port: CDP_PORT, target: shell.id });
+  await shellClient.Runtime.enable();
+
+  // Click the close button on the active tab
+  const { result } = await shellClient.Runtime.evaluate({
+    expression: `
+      (() => {
+        const activeTab = document.querySelector('.tab.active');
+        if (!activeTab) return 'no active tab';
+        const closeBtn = activeTab.querySelector('.tab-close-button-container button');
+        if (!closeBtn) return 'no close button';
+        closeBtn.click();
+        return 'closed';
+      })()
+    `,
+    returnByValue: true,
   });
-  await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'w', code: 'KeyW' });
+  await shellClient.close();
+
+  if (result.value !== 'closed') {
+    throw new Error(`Failed to close tab: ${result.value}`);
+  }
 
   await new Promise(r => setTimeout(r, 1000));
 
+  // Reconnect to the first available chart tab
   const after = await list();
+  if (after.tabs.length > 0) {
+    await connectToTarget(after.tabs[0].id);
+  }
+
   return { success: true, action: 'tab_closed', tabs_before: before.tab_count, tabs_after: after.tab_count };
 }
 

--- a/src/tools/tab.js
+++ b/src/tools/tab.js
@@ -8,8 +8,11 @@ export function registerTabTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tab_new', 'Open a new chart tab', {}, async () => {
-    try { return jsonResult(await core.newTab()); }
+  server.tool('tab_new', 'Open a new chart tab', {
+    type: z.string().optional().describe('Tab type to open (e.g. "layout"). Omit to stay on selection screen.'),
+    name: z.string().optional().describe('Name of the item to select (e.g. layout name). Required when type is specified.'),
+  }, async ({ type, name }) => {
+    try { return jsonResult(await core.newTab({ type, name })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 

--- a/tests/e2e.test.js
+++ b/tests/e2e.test.js
@@ -1428,6 +1428,85 @@ val = array.get(a, 5)`;
 
   // ─── 13. CONTEXT SIZE VALIDATION ──────────────────────────────────────
 
+  // ─── TAB MANAGEMENT (4 tools) ──────────────────────────────────────────
+
+  describe('Tab Management', () => {
+    let tabCountBefore;
+    let tab;
+
+    it('tab_list — list open chart tabs', async () => {
+      tab = await import('../src/core/tab.js');
+      const result = await tab.list();
+      assert.ok(result.success, 'tab_list succeeded');
+      assert.ok(result.tab_count >= 1, 'At least one chart tab open');
+      assert.ok(Array.isArray(result.tabs), 'tabs is an array');
+      tabCountBefore = result.tab_count;
+    });
+
+    it('tab_new — open new tab with layout', async () => {
+      const result = await tab.newTab({ type: 'layout', name: 'Analysis' });
+      assert.ok(result.success, 'tab_new succeeded');
+      assert.strictEqual(result.type, 'layout');
+      assert.strictEqual(result.name, 'Analysis');
+      assert.ok(result.tab_id, 'New tab has an ID');
+      assert.strictEqual(result.tab_count, tabCountBefore + 1, 'Tab count increased by 1');
+    });
+
+    it('tab_close — close the new tab', async () => {
+      const result = await tab.closeTab();
+      assert.ok(result.success, 'tab_close succeeded');
+      assert.strictEqual(result.tabs_after, result.tabs_before - 1, 'Tab count decreased by 1');
+      assert.strictEqual(result.tabs_after, tabCountBefore, 'Tab count restored to original');
+    });
+
+    it('tab_switch — switch to tab and verify CDP reconnects', async () => {
+      const tabs = await tab.list();
+      assert.ok(tabs.tab_count >= 1, 'Have tabs to switch to');
+
+      const result = await tab.switchTab({ index: 0 });
+      assert.ok(result.success, 'tab_switch succeeded');
+      assert.strictEqual(result.index, 0);
+      assert.ok(result.tab_id, 'Switched tab has an ID');
+      assert.strictEqual(result.tab_id, tabs.tabs[0].id, 'Connected to correct target');
+    });
+
+    it('tab_switch — rejects out-of-range index', async () => {
+      await assert.rejects(
+        () => tab.switchTab({ index: 999 }),
+        /out of range/
+      );
+    });
+  });
+
+  // ─── CONNECTTOTARGET (connection.js) ──────────────────────────────────
+
+  describe('connectToTarget', () => {
+    let connectToTarget;
+
+    it('connects to a valid target ID', async () => {
+      ({ connectToTarget } = await import('../src/connection.js'));
+      const targets = await CDP.List({ host: 'localhost', port: 9222 });
+      const chart = targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url));
+      assert.ok(chart, 'Found a chart target');
+
+      const newClient = await connectToTarget(chart.id);
+      assert.ok(newClient, 'Got a client back');
+
+      const { result } = await newClient.Runtime.evaluate({
+        expression: '1 + 1',
+        returnByValue: true,
+      });
+      assert.strictEqual(result.value, 2, 'Client can evaluate expressions');
+    });
+
+    it('throws for non-existent target ID', async () => {
+      await assert.rejects(
+        () => connectToTarget('non-existent-target-id-12345'),
+        /not found/
+      );
+    });
+  });
+
   describe('Context Size Validation', () => {
 
     it('quote_get output < 500 bytes', async () => {


### PR DESCRIPTION
## Summary
  Tab operations (tab_new, tab_switch, tab_close) were non-functional because:
  1. The CDP client never reconnected when switching tabs
  2. Keyboard shortcuts (Ctrl+T, Ctrl+W) don't reach TradingView Desktop's Electron shell

  ## Changes

  ### CDP reconnection (connection.js)
  - Added `connectToTarget(targetId)` — closes existing CDP connection and reconnects to a specific target

  ### tab_switch (core/tab.js)
  - Now calls `connectToTarget()` after activating a tab, so subsequent operations run on the correct tab

  ### tab_new (core/tab.js)
  - Replaced Ctrl+T keyboard shortcut with clicking `.create-new-tab-button` on the Electron shell target
  - Accepts optional `type` ("layout") and `name` params to select a layout from the new tab screen
  - Extensible to other tab types (heatmap, screener, etc.) in the future

  ### tab_close (core/tab.js)
  - Replaced Ctrl+W with clicking the active tab's close button on the Electron shell
  - Auto-dismisses the "unsaved changes" dialog (polls for the dialog's CDP target)
  - Reconnects to the first remaining chart tab after closing

  ### dismissUnsavedDialog (core/tab.js)
  - Only checks `file://` targets (dialog is an Electron window, not a chart page)
  - Skips empty-URL targets to avoid hanging on unresponsive targets
  - Uses a 2-second connection timeout per target

  ## Tests (7 new)

  All tests are e2e against a live TradingView Desktop instance.

  **Tab Management (5 tests):**
  - `tab_list` — lists open chart tabs
  - `tab_new` — opens a new tab with a specified layout (Analysis)
  - `tab_close` — closes the active tab, verifies count decreases, auto-dismisses unsaved changes dialog
  - `tab_switch` — switches to a tab by index, verifies CDP reconnects to the correct target
  - `tab_switch` — rejects out-of-range index with descriptive error

  **connectToTarget (2 tests):**
  - Connects to a valid target ID and verifies the client can evaluate expressions
  - Throws for a non-existent target ID

  ## Testing
  - New tests run independently: 7/7 pass
    node --test --test-name-pattern "Tab Management|connectToTarget" tests/e2e.test.js
  - Full suite: hangs on pre-existing `ui_scroll` test before reaching new tests (same behavior on main branch)
  - No new failures introduced in tests that do run
  - Manually verified full tab lifecycle: open Analysis layout → scan indicators → close tab → dialog auto-dismissed