### PR TITLE
Add MCP config, dev server launch, and OR Rejection Scalper strategy

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "MCP Server (stdio)",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["src/server.js"],
+      "port": 9222
+    },
+    {
+      "name": "Scalper Bot (Bitget XRP/USDT)",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["scalper-run.js"],
+      "port": 0
+    }
+  ]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "tradingview": {
+      "command": "node",
+      "args": ["src/server.js"],
+      "cwd": "/Users/chrisberton/tradingview-mcp-jackson"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- **`.mcp.json`**: Registers the TradingView MCP server so Claude Code can access all 78 chart tools via CDP
- **`.claude/launch.json`**: Dev server configurations for the MCP server (port 9222) and scalper bot
- **OR Rejection Scalper strategy**: Multi-session Pine Script strategy built from scratch with:
  - 5-min Opening Range detection per session (Asian, London, NY)
  - Break → retest → engulfing candle entry pattern
  - Multi-timeframe EMA confirmation (1m, 5m, 15m) + KAMA 14 filter
  - VWAP + 1 SD bands for dynamic TP2 targeting
  - Swing-level TP1 with min 2:1 R:R, scale-out at TP1/TP2, trail runner
  - KAMA invalidation stop (closes trade if price reclaims KAMA pre-TP1)
  - 5-min engulfing confirmation option

## Test plan
- [ ] Verify MCP server connects via `tv_health_check` after loading `.mcp.json`
- [ ] Compile strategy in Pine Editor — should produce zero errors
- [ ] Run on 1-min MNQ/MES futures across Asian, London, and NY sessions
- [ ] Validate OR levels plot correctly at each session open
- [ ] Confirm entries only fire after break → retest → engulfing pattern
- [ ] Check TP1/TP2 scaling and trail stop behavior in Strategy Tester

🤖 Generated with [Claude Code](https://claude.com/claude-code)