### PR TITLE
Add .claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ scripts/current.pine
 temp_*
 *.log
 discovery-log.json
+.claude/


### PR DESCRIPTION
## Summary
- Added `.claude/` to `.gitignore` to prevent local Claude Code session files (e.g., `settings.local.json`) from being accidentally committed

## Test plan
- [ ] Confirm `.claude/` no longer appears as untracked in `git status`
- [ ] Verify no other local-only files are accidentally tracked

🤖 Generated with Claude Code