### PR TITLE
Migrate strategy from BTC crypto scalper to US equity options scalper

### DIFF
--- a/rules.example.json
+++ b/rules.example.json
@@ -1,31 +1,71 @@
 {
-  "watchlist": ["BTCUSD", "ETHUSD", "SOLUSD"],
-  "default_timeframe": "240",
+  "watchlist": ["AMZN", "MSFT", "AAPL", "AMD", "NVDA"],
+  "default_timeframe": "1",
+  "asset_type": "equity_options",
 
-  "bias_criteria": {
-    "bullish": [
-      "Ribbon direction is up (bullish colour)",
-      "Price is above the 20 EMA on the 4H",
-      "RSI is below 60 (room to run)"
+  "strategy": {
+    "name": "1-Minute Options Scalper",
+    "instrument": "0DTE or next-expiry ATM options (CALL for long bias, PUT for short bias)",
+    "sources": [
+      "Price momentum — 1-min candle close vs previous close",
+      "RSI filter — only trade between 35–65",
+      "VWAP filter — price above VWAP favors CALLs, below favors PUTs",
+      "Volume confirmation — current bar volume must exceed 20-bar average"
     ],
-    "bearish": [
-      "Ribbon direction is down (bearish colour)",
-      "Price is below the 20 EMA on the 4H",
-      "RSI is above 40 (room to drop)"
-    ],
-    "neutral": [
-      "Ribbon is flat or mixed",
-      "Price is chopping around the 20 EMA",
-      "RSI is between 45 and 55"
+    "primary_timeframes": [
+      "1-minute (signal source and execution)",
+      "5-minute (bias/trend context)"
     ]
   },
 
-  "risk_rules": [
-    "Only take trades where R:R is at least 1:2",
-    "No trading in the first 15 minutes of the NY session open",
-    "Maximum 2 open positions at once",
-    "If I have 2 losing trades in a row, stop for the day"
+  "vix_filter": {
+    "description": "Check CBOE:VIX before every trade. VIX level determines regime.",
+    "regimes": {
+      "normal":   { "vix_range": "below 20",  "action": "Full size, trade normally" },
+      "elevated": { "vix_range": "20 to 30",  "action": "50% size, widen stop to -20%" },
+      "high":     { "vix_range": "30 to 40",  "action": "25% size, 1 trade max, AMZN/MSFT only" },
+      "extreme":  { "vix_range": "above 40",  "action": "STOP — no trades" }
+    }
+  },
+
+  "bias_criteria": {
+    "bullish_call": [
+      "Last 1-min candle closed higher than the one before it by at least 0.10%",
+      "RSI is between 35 and 65",
+      "Price is above VWAP",
+      "Volume is above 20-bar average"
+    ],
+    "bearish_put": [
+      "Last 1-min candle closed lower than the one before it by at least 0.10%",
+      "RSI is between 35 and 65",
+      "Price is below VWAP",
+      "Volume is above 20-bar average"
+    ],
+    "neutral_skip": [
+      "RSI is above 65 (overbought — skip)",
+      "RSI is below 35 (oversold — skip)",
+      "Candle close change is less than 0.10% (chop — skip)",
+      "Price is within 0.05% of VWAP (indecision — skip)",
+      "Volume is below 20-bar average (low conviction — skip)",
+      "VIX is above 40 (extreme regime — no trades)"
+    ]
+  },
+
+  "exit_rules": [
+    "Profit target: exit when option premium gains +25%",
+    "Stop loss: exit when option premium loses -15% (or -20% when VIX is elevated)",
+    "Time stop: exit after 5 minutes regardless of P&L",
+    "Hard close: exit all positions by 3:30 PM EST"
   ],
 
-  "notes": "Add any other context you want Claude to factor in — e.g. macro events this week, key dates, anything that should affect your bias."
+  "risk_rules": [
+    "Check VIX regime FIRST — see vix_filter for size and permission rules",
+    "Maximum premium per trade: $50 normal | $25 elevated | $12 high VIX",
+    "Maximum 3 open positions (1 max when VIX is high)",
+    "Maximum 10 trades per session",
+    "Do not trade during earnings week on single stocks",
+    "Paper trade first to validate signals"
+  ],
+
+  "notes": "Starter config for the 1-minute options scalper. Swap in your own watchlist. Requires TradingView Desktop open on port 9222."
 }

--- a/rules.json
+++ b/rules.json
@@ -1,65 +1,136 @@
 {
-  "watchlist": ["BTCUSDT"],
+  "watchlist": ["MU", "AMZN", "PLTR", "SOFI", "NFLX", "MSFT", "APP", "AMD", "VIX"],
   "default_timeframe": "1",
+  "asset_type": "equity_options",
 
   "strategy": {
-    "name": "10-Second Momentum Scalper",
+    "name": "1-Minute Options Scalper",
+    "instrument": "0DTE or next-expiry ATM options (CALL for long bias, PUT for short bias)",
     "sources": [
-      "Price momentum — buy if last close > previous close (green candle)",
-      "RSI filter — only trade when RSI is not at an extreme (30–70 range)"
+      "Price momentum — 1-min candle close vs previous close",
+      "RSI filter — only trade between 35–65 (tighter band than crypto)",
+      "VWAP filter — price above VWAP favors CALLs, below favors PUTs",
+      "Volume confirmation — current bar volume must exceed 20-bar average"
     ],
     "primary_timeframes": [
-      "1-minute (signal source)",
-      "10-second execution loop"
+      "1-minute (signal source and execution)",
+      "5-minute (bias/trend context)"
     ]
   },
 
   "indicators": {
-    "rsi_14": "Momentum filter. Only trade when RSI is between 30–70 (avoid extremes).",
-    "price_momentum": "Compare last close vs previous close. Up = long signal. Down = short signal."
+    "rsi_14": "Momentum filter. Only trade when RSI is between 35–65. Tighter than crypto to avoid chop.",
+    "vwap": "Directional bias. Price above VWAP = favor CALLs. Price below VWAP = favor PUTs.",
+    "volume": "Confirmation filter. Only enter if 1-min bar volume is above the 20-bar average.",
+    "price_momentum": "Compare last 1-min close vs previous close. Minimum 0.10% move required (stocks move less than crypto).",
+    "vix": "Volatility regime filter. Check VIX level before every trade. Governs position size and trade permission — see vix_filter."
+  },
+
+  "vix_filter": {
+    "description": "Check CBOE:VIX on TradingView before entering any trade. VIX level determines regime.",
+    "regimes": {
+      "low": {
+        "vix_range": "below 15",
+        "action": "Trade normally — full size, standard rules apply",
+        "note": "Low volatility = smaller option premiums, tighter moves. Scalps may be smaller."
+      },
+      "normal": {
+        "vix_range": "15 to 20",
+        "action": "Trade normally — full size, standard rules apply",
+        "note": "Ideal scalping environment."
+      },
+      "elevated": {
+        "vix_range": "20 to 30",
+        "action": "Reduce position size by 50%. Widen stop loss to -20% on premium.",
+        "note": "More volatile — premiums expand but reversals are faster. Smaller size protects capital."
+      },
+      "high": {
+        "vix_range": "30 to 40",
+        "action": "Max 1 trade at a time. Reduce size to 25% of normal. Only trade AMZN or MSFT (most liquid).",
+        "note": "Market is in stress. Most scalp setups will fail. Be very selective."
+      },
+      "extreme": {
+        "vix_range": "above 40",
+        "action": "STOP TRADING — sit out entirely",
+        "note": "Extreme fear/dislocation. Spreads blow out, fills are unreliable. No edge exists for scalping."
+      }
+    }
+  },
+
+  "market_hours": {
+    "session": "NYSE/NASDAQ — 9:30 AM to 4:00 PM EST",
+    "avoid_open": "Skip first 15 minutes (9:30–9:45 AM) — spreads are wide and price is erratic",
+    "avoid_close": "Stop trading at 3:30 PM — 0DTE theta decay accelerates sharply in final 30 min",
+    "avoid_events": "No trades within 30 minutes of scheduled earnings, FOMC, or CPI announcements"
   },
 
   "bias_criteria": {
-    "bullish": [
-      "Last 1-min candle closed higher than the one before it",
-      "RSI is between 30 and 70"
+    "bullish_call": [
+      "Last 1-min candle closed higher than the one before it by at least 0.10%",
+      "RSI is between 35 and 65",
+      "Price is above VWAP",
+      "Volume is above 20-bar average"
     ],
-    "bearish": [
-      "Last 1-min candle closed lower than the one before it",
-      "RSI is between 30 and 70"
+    "bearish_put": [
+      "Last 1-min candle closed lower than the one before it by at least 0.10%",
+      "RSI is between 35 and 65",
+      "Price is below VWAP",
+      "Volume is above 20-bar average"
     ],
-    "neutral": [
-      "RSI is above 70 (overbought — skip)",
-      "RSI is below 30 (oversold — skip)",
-      "Candle close change is less than 0.05% (chop — skip)"
+    "neutral_skip": [
+      "RSI is above 65 (overbought — skip)",
+      "RSI is below 35 (oversold — skip)",
+      "Candle close change is less than 0.10% (chop — skip)",
+      "Price is within 0.05% of VWAP (indecision — skip)",
+      "Volume is below 20-bar average (low conviction — skip)",
+      "VIX is above 40 (extreme regime — no trades at all)"
     ]
   },
 
   "entry_rules": {
-    "long": [
-      "Last close > previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market buy immediately"
+    "call": [
+      "All bullish_call criteria met",
+      "Buy ATM CALL — nearest expiry (0DTE preferred on SPY/QQQ, next weekly on single stocks)",
+      "Strike: at-the-money or one strike in-the-money",
+      "Enter at market on next 1-min candle open"
     ],
-    "short": [
-      "Last close < previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market sell immediately"
+    "put": [
+      "All bearish_put criteria met",
+      "Buy ATM PUT — nearest expiry (0DTE preferred on SPY/QQQ, next weekly on single stocks)",
+      "Strike: at-the-money or one strike in-the-money",
+      "Enter at market on next 1-min candle open"
     ]
   },
 
   "exit_rules": [
-    "Exit automatically after 10 seconds (next loop tick closes previous position)",
-    "No manual exit management — pure time-based scalp"
+    "Profit target: exit when option premium gains +25% from entry price",
+    "Stop loss: exit when option premium loses -15% from entry price",
+    "Time stop: exit after 5 minutes regardless of P&L — do not hold a scalp longer than 5 bars",
+    "Hard close: exit ALL positions by 3:30 PM — never hold 0DTE into the final 30 minutes"
   ],
 
   "risk_rules": [
-    "Fixed trade size: 1% of portfolio per trade",
-    "Maximum trade size: $3.00",
-    "Maximum 6 trades per 60-second run",
-    "No stop loss — exit is time-based at next tick",
-    "For demo purposes only — minimum BitGet order size may apply"
+    "Check VIX regime FIRST before placing any trade — see vix_filter for size and permission rules",
+    "Fixed risk per trade: 1% of account per option contract (scale down per vix_filter in elevated+ regimes)",
+    "Maximum premium per trade: $50 normal, $25 when VIX is elevated (20–30), $12 when VIX is high (30–40)",
+    "Maximum 3 open positions at one time (1 max when VIX is high)",
+    "Maximum 10 trades per trading session",
+    "Only trade AMZN or MSFT when VIX is above 30 — tightest spreads under stress",
+    "Do not trade during earnings week on single stocks",
+    "Paper trade first — validate signal accuracy before using real capital"
   ],
 
-  "notes": "Demo strategy for YouTube video. Runs 6 trades over 60 seconds, one every 10 seconds. Signal is simple price momentum on 1-min candles with RSI sanity check."
+  "symbol_guidance": {
+    "MU": "Semiconductor. Earnings-sensitive — check calendar before trading. Good options volume.",
+    "AMZN": "Mega-cap. Tight spreads, reliable liquidity. Strong VWAP respector intraday.",
+    "PLTR": "High retail interest, decent options volume. Can gap — watch size on volatile days.",
+    "SOFI": "Smaller cap — expect wider bid/ask spreads. Use smaller size, confirm volume filter.",
+    "NFLX": "High IV — premiums are expensive. Only enter on very strong momentum signals.",
+    "MSFT": "Mega-cap. Tight spreads, consistent liquidity. Good for cleaner scalp setups.",
+    "APP": "High momentum stock. Fast moves — honor the 5-minute time stop strictly.",
+    "AMD": "Semiconductor. High options volume, strong intraday moves. Good scalping candidate.",
+    "VIX": "Volatility index — DO NOT trade options on VIX directly. Use as a filter: VIX above 20 = wider stops allowed, VIX above 30 = reduce size or skip scalps entirely."
+  },
+
+  "notes": "Options scalping strategy for high-liquidity US equities. Uses 1-min momentum + RSI + VWAP + volume filters. Buys short-dated ATM calls or puts. Exits on profit target (+25%), stop (-15%), or 5-minute time stop. Avoid first/last 30 min of session. Paper trade to validate before going live."
 }

--- a/safety-check-log.json
+++ b/safety-check-log.json
@@ -1,198 +1,73 @@
 [
   {
-    "timestamp": "2026-04-07T00:00:00Z",
-    "symbol": "BINANCE:BTCUSDT",
-    "timeframe": "4H",
-    "indicators": {
-      "price": 68334.79,
-      "ema_21": 68314.99,
-      "ema_50": 67981.18,
-      "ema_200": 69116.13,
-      "rsi_14": 51.95,
-      "macd_line": 385.87,
-      "signal_line": 421.52,
-      "macd_histogram": -35.65
+    "event": "STRATEGY_MIGRATION",
+    "timestamp": "2026-04-12T00:00:00Z",
+    "migratedFrom": "10-Second Momentum Scalper (BTCUSDT — BitGet spot crypto)",
+    "migratedTo": "1-Minute Options Scalper (US Equity Options — TradingView)",
+    "clearedEntries": 13,
+    "reason": "All prior log entries were from crypto/XRP runs and are no longer relevant to the active strategy."
+  },
+  {
+    "event": "SETTINGS_CONFIRMATION",
+    "timestamp": "2026-04-12T00:00:00Z",
+    "status": "CONFIRMED",
+    "strategy": {
+      "name": "1-Minute Options Scalper",
+      "asset_type": "equity_options",
+      "instrument": "ATM CALL (bullish) or ATM PUT (bearish) — 0DTE or next weekly expiry",
+      "default_timeframe": "1-minute"
     },
-    "conditions": {
-      "price_above_ema200": {
-        "required": true,
-        "actual": false,
-        "result": "FAIL"
-      },
-      "ema21_above_ema50": {
-        "required": true,
-        "actual": true,
-        "result": "PASS"
-      },
-      "price_in_ema21_50_zone": {
-        "required": true,
-        "actual": false,
-        "result": "FAIL"
-      },
-      "rsi_35_to_58": {
-        "required": true,
-        "actual": true,
-        "result": "PASS"
-      },
-      "macd_above_signal": {
-        "required": true,
-        "actual": false,
-        "result": "FAIL"
-      }
+    "watchlist": {
+      "symbols": ["MU", "AMZN", "PLTR", "SOFI", "NFLX", "MSFT", "APP", "AMD"],
+      "filter_only": ["VIX"],
+      "note": "VIX is a regime filter — not a tradeable symbol in this strategy"
     },
-    "verdict": "BLOCKED",
-    "blocked_reasons": [
-      "Price below EMA 200 (68334 < 69116) — no longs against macro trend",
-      "Price above EMA 21-50 zone — no pullback entry available",
-      "MACD bearish (385.87 < 421.52) — momentum fading"
-    ],
-    "orderPlaced": false
-  },
-  {
-    "tick": 1,
-    "timestamp": "2026-04-07T14:41:41.675Z",
-    "price": 1.3001,
-    "side": "buy",
-    "size": "7.0745",
-    "label": "BUY XRP with $7.0745 USDT",
-    "orderId": "1425421555869495297",
-    "orderPlaced": true,
-    "response": {
-      "code": "00000",
-      "msg": "success",
-      "requestTime": 1775572902637,
-      "data": {
-        "orderId": "1425421555869495297",
-        "clientOid": "cee1fed1-1b60-466e-9583-a7db21f82711"
-      }
+    "indicators_confirmed": {
+      "rsi_14": "Trade only when RSI is between 35 and 65",
+      "vwap": "Price above VWAP = CALL bias | Price below VWAP = PUT bias",
+      "volume": "Current bar must exceed 20-bar average volume",
+      "price_momentum": "Minimum 0.10% candle move required to trigger signal"
+    },
+    "vix_regimes_confirmed": {
+      "below_15":  "Normal — full size",
+      "15_to_20":  "Normal — full size",
+      "20_to_30":  "Elevated — 50% size, stop widens to -20%",
+      "30_to_40":  "High — 25% size, 1 trade max, AMZN/MSFT only",
+      "above_40":  "Extreme — NO TRADES"
+    },
+    "entry_rules_confirmed": {
+      "call": "Momentum up ≥ 0.10% + RSI 35–65 + price above VWAP + volume above avg → Buy ATM CALL",
+      "put":  "Momentum down ≥ 0.10% + RSI 35–65 + price below VWAP + volume above avg → Buy ATM PUT"
+    },
+    "exit_rules_confirmed": {
+      "profit_target": "+25% on option premium",
+      "stop_loss": "-15% on premium (-20% when VIX is elevated)",
+      "time_stop": "5 minutes max hold per trade",
+      "hard_close": "All positions closed by 3:30 PM EST"
+    },
+    "risk_rules_confirmed": {
+      "max_premium_normal":   "$50 per trade",
+      "max_premium_elevated": "$25 per trade (VIX 20–30)",
+      "max_premium_high":     "$12 per trade (VIX 30–40)",
+      "max_open_positions":   "3 (1 when VIX is high)",
+      "max_trades_per_day":   10,
+      "account_risk_per_trade": "1% of portfolio"
+    },
+    "market_hours_confirmed": {
+      "session": "NYSE/NASDAQ — 9:30 AM to 4:00 PM EST",
+      "no_trade_open": "9:30–9:45 AM (wide spreads)",
+      "no_trade_close": "3:30–4:00 PM (0DTE theta risk)",
+      "no_trade_events": "Within 30 min of earnings, FOMC, or CPI"
+    },
+    "symbol_notes": {
+      "MU":   "Good options volume. Check earnings calendar.",
+      "AMZN": "Mega-cap. Tight spreads. Preferred under high VIX.",
+      "PLTR": "Decent volume. Can gap — watch size.",
+      "SOFI": "Smaller cap. Wider spreads. Use reduced size.",
+      "NFLX": "High IV. Expensive premiums. Strong signal required.",
+      "MSFT": "Mega-cap. Tight spreads. Preferred under high VIX.",
+      "APP":  "Fast mover. Honor the 5-min time stop strictly.",
+      "AMD":  "High options volume. Strong intraday moves."
     }
-  },
-  {
-    "tick": 2,
-    "timestamp": "2026-04-07T14:41:52.759Z",
-    "price": 1.3,
-    "side": "sell",
-    "size": "5.4361",
-    "label": "SELL 5.4361 XRP → USDT",
-    "orderId": "0.0001111305XRP can be used at most",
-    "orderPlaced": false,
-    "response": {
-      "code": "12001",
-      "msg": "0.0001111305XRP can be used at most",
-      "requestTime": 1775572913620,
-      "data": null
-    }
-  },
-  {
-    "tick": 3,
-    "timestamp": "2026-04-07T14:42:03.718Z",
-    "price": 1.2998,
-    "side": "sell",
-    "size": "5.4361",
-    "label": "SELL 5.4361 XRP → USDT",
-    "orderId": "0.0001111305XRP can be used at most",
-    "orderPlaced": false,
-    "response": {
-      "code": "12001",
-      "msg": "0.0001111305XRP can be used at most",
-      "requestTime": 1775572924541,
-      "data": null
-    }
-  },
-  {
-    "tick": 4,
-    "timestamp": "2026-04-07T14:42:14.707Z",
-    "price": 1.2998,
-    "side": "sell",
-    "size": "5.4361",
-    "label": "SELL 5.4361 XRP → USDT",
-    "orderId": "0.0001111305XRP can be used at most",
-    "orderPlaced": false,
-    "response": {
-      "code": "12001",
-      "msg": "0.0001111305XRP can be used at most",
-      "requestTime": 1775572935517,
-      "data": null
-    }
-  },
-  {
-    "tick": 5,
-    "timestamp": "2026-04-07T14:42:25.619Z",
-    "price": 1.2999,
-    "side": "sell",
-    "size": "5.4361",
-    "label": "SELL 5.4361 XRP → USDT",
-    "orderId": "0.0001111305XRP can be used at most",
-    "orderPlaced": false,
-    "response": {
-      "code": "12001",
-      "msg": "0.0001111305XRP can be used at most",
-      "requestTime": 1775572946426,
-      "data": null
-    }
-  },
-  {
-    "tick": 6,
-    "timestamp": "2026-04-07T14:42:36.533Z",
-    "price": 1.2999,
-    "side": "sell",
-    "size": "5.4361",
-    "label": "SELL 5.4361 XRP → USDT",
-    "orderId": "0.0001111305XRP can be used at most",
-    "orderPlaced": false,
-    "response": {
-      "code": "12001",
-      "msg": "0.0001111305XRP can be used at most",
-      "requestTime": 1775572957307,
-      "data": null
-    }
-  },
-  {
-    "tick": 1,
-    "timestamp": "2026-04-07T14:44:05.883Z",
-    "price": 1.2991,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
-  },
-  {
-    "tick": 2,
-    "timestamp": "2026-04-07T14:44:16.746Z",
-    "price": 1.2991,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
-  },
-  {
-    "tick": 3,
-    "timestamp": "2026-04-07T14:44:27.448Z",
-    "price": 1.2996,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
-  },
-  {
-    "tick": 4,
-    "timestamp": "2026-04-07T14:44:38.140Z",
-    "price": 1.2991,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
-  },
-  {
-    "tick": 5,
-    "timestamp": "2026-04-07T14:44:48.846Z",
-    "price": 1.2991,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
-  },
-  {
-    "tick": 6,
-    "timestamp": "2026-04-07T14:44:59.488Z",
-    "price": 1.299,
-    "side": "skip",
-    "reason": "balance too low",
-    "orderPlaced": false
   }
 ]

--- a/scalper-run.js
+++ b/scalper-run.js
@@ -1,124 +1,34 @@
-import { createHmac } from "crypto";
-import https from "https";
 import { existsSync, readFileSync, writeFileSync } from "fs";
+import * as chart from "./src/core/chart.js";
+import * as data from "./src/core/data.js";
 
-// Load .env
-readFileSync(new URL(".env", import.meta.url), "utf8")
-  .split("\n")
-  .forEach((line) => {
-    const [k, ...v] = line.split("=");
-    if (k && !k.startsWith("#") && v.length)
-      process.env[k.trim()] = v.join("=").trim();
-  });
+// ── Config ───────────────────────────────────────────────────────
+const rules = JSON.parse(readFileSync("rules.json", "utf8"));
+const { watchlist, vix_filter, bias_criteria, exit_rules, risk_rules } = rules;
 
-const API_KEY = process.env.BITGET_API_KEY;
-const SECRET_KEY = process.env.BITGET_SECRET_KEY;
-const PASSPHRASE = process.env.BITGET_PASSPHRASE;
+const SCAN_DELAY_MS = 3000;   // wait between symbol switches
+const MIN_MOMENTUM_PCT = 0.10; // minimum candle move % to count as signal
 
-const SYMBOL = "XRPUSDT"; // XRP/USDT spot — low price, above min order size
-const INTERVAL_MS = 10000; // 10 seconds
-const TOTAL_TRADES = 6;
-
-// ── BitGet helpers ──────────────────────────────────────────────
-function sign(ts, method, path, body = "") {
-  return createHmac("sha256", SECRET_KEY)
-    .update(ts + method + path + body)
-    .digest("base64");
+// ── VIX Regime ───────────────────────────────────────────────────
+function getVixRegime(vixLevel) {
+  if (vixLevel > 40) return "extreme";
+  if (vixLevel > 30) return "high";
+  if (vixLevel > 20) return "elevated";
+  return "normal";
 }
 
-function request(method, path, body = null) {
-  return new Promise((resolve, reject) => {
-    const ts = Date.now().toString();
-    const bodyStr = body ? JSON.stringify(body) : "";
-    const sig = sign(ts, method, path, bodyStr);
-    const req = https.request(
-      {
-        hostname: "api.bitget.com",
-        path,
-        method,
-        headers: {
-          "Content-Type": "application/json",
-          "ACCESS-KEY": API_KEY,
-          "ACCESS-SIGN": sig,
-          "ACCESS-TIMESTAMP": ts,
-          "ACCESS-PASSPHRASE": PASSPHRASE,
-          locale: "en-US",
-        },
-      },
-      (res) => {
-        let d = "";
-        res.on("data", (c) => (d += c));
-        res.on("end", () => resolve(JSON.parse(d)));
-      },
-    );
-    req.on("error", reject);
-    if (bodyStr) req.write(bodyStr);
-    req.end();
-  });
+function getSizeMultiplier(regime) {
+  const map = { normal: 1.0, elevated: 0.5, high: 0.25, extreme: 0 };
+  return map[regime] ?? 1.0;
 }
 
-// ── Market data ─────────────────────────────────────────────────
-async function getCandles(symbol, limit = 30) {
-  // 1-minute candles from BitGet
-  const res = await request(
-    "GET",
-    `/api/v2/spot/market/candles?symbol=${symbol}&granularity=1min&limit=${limit}`,
-  );
-  // returns [[ts, open, high, low, close, vol], ...]
-  return (res.data || []).map((c) => ({
-    ts: parseInt(c[0]),
-    open: parseFloat(c[1]),
-    high: parseFloat(c[2]),
-    low: parseFloat(c[3]),
-    close: parseFloat(c[4]),
-    vol: parseFloat(c[5]),
-  }));
+function getStopLossPct(regime) {
+  return regime === "elevated" ? 20 : 15; // widen stop in elevated VIX
 }
 
-async function getPrice(symbol) {
-  const res = await request(
-    "GET",
-    `/api/v2/spot/market/tickers?symbol=${symbol}`,
-  );
-  return parseFloat(res.data?.[0]?.lastPr || 0);
-}
-
-async function getBalances() {
-  const res = await request("GET", "/api/v2/spot/account/assets");
-  const usdt = res.data?.find((a) => a.coin === "USDT");
-  const xrp = res.data?.find((a) => a.coin === "XRP");
-  return {
-    usdt: parseFloat(usdt?.available || 0),
-    xrp: parseFloat(xrp?.available || 0),
-  };
-}
-
-// ── Indicators ──────────────────────────────────────────────────
-function calcEMA(closes, period) {
-  const k = 2 / (period + 1);
-  let ema = closes[0];
-  for (let i = 1; i < closes.length; i++) ema = closes[i] * k + ema * (1 - k);
-  return ema;
-}
-
-function calcRSI(closes, period = 3) {
-  if (closes.length < period + 1) return 50;
-  let gains = 0,
-    losses = 0;
-  for (let i = closes.length - period; i < closes.length; i++) {
-    const diff = closes[i] - closes[i - 1];
-    if (diff > 0) gains += diff;
-    else losses -= diff;
-  }
-  if (losses === 0) return 100;
-  const rs = gains / losses;
-  return 100 - 100 / (1 + rs);
-}
-
+// ── Indicators ───────────────────────────────────────────────────
 function calcVWAP(candles) {
-  // Session VWAP approximation (all candles provided)
-  let cumTPV = 0,
-    cumVol = 0;
+  let cumTPV = 0, cumVol = 0;
   for (const c of candles) {
     const tp = (c.high + c.low + c.close) / 3;
     cumTPV += tp * c.vol;
@@ -127,212 +37,197 @@ function calcVWAP(candles) {
   return cumVol === 0 ? candles[candles.length - 1].close : cumTPV / cumVol;
 }
 
-// ── Signal logic (mirrors Pine Script) ─────────────────────────
+function calcRSI(closes, period = 14) {
+  if (closes.length < period + 1) return 50;
+  let gains = 0, losses = 0;
+  for (let i = closes.length - period; i < closes.length; i++) {
+    const diff = closes[i] - closes[i - 1];
+    if (diff > 0) gains += diff;
+    else losses -= diff;
+  }
+  if (losses === 0) return 100;
+  return 100 - 100 / (1 + gains / losses);
+}
+
+function avgVolume(candles, period = 20) {
+  const slice = candles.slice(-period);
+  return slice.reduce((s, c) => s + c.vol, 0) / slice.length;
+}
+
+// ── Signal Logic (mirrors rules.json bias_criteria) ───────────────
 function getSignal(candles) {
   const closes = candles.map((c) => c.close);
-  const last = closes[closes.length - 1];
+  const last = candles[candles.length - 1];
+  const prev = candles[candles.length - 2];
 
-  const ema8 = calcEMA(closes, 8);
-  const rsi3 = calcRSI(closes, 3);
+  const rsi = calcRSI(closes);
   const vwap = calcVWAP(candles);
-
-  const bullBias = last > vwap && last > ema8;
-  const bearBias = last < vwap && last < ema8;
+  const avgVol = avgVolume(candles);
+  const momentumPct = ((last.close - prev.close) / prev.close) * 100;
+  const aboveVwap = last.close > vwap;
+  const volumeOk = last.vol > avgVol;
 
   let signal = "flat";
-  if (bullBias && rsi3 < 30) signal = "buy";
-  else if (bearBias && rsi3 > 70) signal = "sell";
+  let skipReason = null;
 
-  return { signal, last, ema8, rsi3, vwap };
-}
-
-// ── Order helpers ───────────────────────────────────────────────
-async function placeOrder(side, size) {
-  const body = {
-    symbol: SYMBOL,
-    side,
-    orderType: "market",
-    force: "gtc",
-    size,
-  };
-  return request("POST", "/api/v2/spot/trade/place-order", body);
-}
-
-async function getOrderFill(orderId) {
-  for (let i = 0; i < 5; i++) {
-    await new Promise((r) => setTimeout(r, 1000));
-    const res = await request(
-      "GET",
-      `/api/v2/spot/trade/orderInfo?orderId=${orderId}&symbol=${SYMBOL}`,
-    );
-    const fill = parseFloat(res.data?.baseVolume || 0);
-    if (fill > 0) return fill;
+  // Neutral / skip conditions
+  if (rsi > 65) {
+    skipReason = `RSI ${rsi.toFixed(1)} > 65 (overbought)`;
+  } else if (rsi < 35) {
+    skipReason = `RSI ${rsi.toFixed(1)} < 35 (oversold)`;
+  } else if (Math.abs(momentumPct) < MIN_MOMENTUM_PCT) {
+    skipReason = `Momentum ${momentumPct.toFixed(3)}% < ${MIN_MOMENTUM_PCT}% (chop)`;
+  } else if (Math.abs((last.close - vwap) / vwap * 100) < 0.05) {
+    skipReason = `Price within 0.05% of VWAP (indecision)`;
+  } else if (!volumeOk) {
+    skipReason = `Volume ${last.vol.toFixed(0)} below 20-bar avg ${avgVol.toFixed(0)} (low conviction)`;
+  } else if (momentumPct >= MIN_MOMENTUM_PCT && aboveVwap) {
+    signal = "call"; // bullish — buy CALL
+  } else if (momentumPct <= -MIN_MOMENTUM_PCT && !aboveVwap) {
+    signal = "put";  // bearish — buy PUT
+  } else {
+    skipReason = `VWAP conflict — momentum ${momentumPct > 0 ? "up" : "down"} but price ${aboveVwap ? "above" : "below"} VWAP`;
   }
-  return 0;
+
+  return { signal, skipReason, rsi, vwap, momentumPct, volumeOk, price: last.close };
 }
 
-// BitGet locks newly purchased assets against immediate resale (anti-wash-trading).
-// This retries the sell, parsing the actually-available amount from the error
-// message until the lock lifts or we time out.
-async function placeSellWithRetry(qty, maxRetries = 12, retryDelayMs = 3000) {
-  for (let attempt = 1; attempt <= maxRetries; attempt++) {
-    const size = (Math.floor(qty * 10000) / 10000).toFixed(4);
-    const res = await placeOrder("sell", size);
+// ── Market Hours Check ────────────────────────────────────────────
+function isMarketOpen() {
+  const now = new Date();
+  const est = new Date(now.toLocaleString("en-US", { timeZone: "America/New_York" }));
+  const h = est.getHours(), m = est.getMinutes();
+  const totalMin = h * 60 + m;
+  const openMin = 9 * 60 + 45;   // 9:45 AM (skip first 15 min)
+  const closeMin = 15 * 60 + 30; // 3:30 PM (stop 30 min early)
+  return totalMin >= openMin && totalMin <= closeMin;
+}
 
-    if (res.code === "00000")
-      return { ok: true, res, soldQty: parseFloat(size) };
+// ── Pull data from TradingView ────────────────────────────────────
+async function getSymbolData(symbol) {
+  await chart.setSymbol({ symbol });
+  await new Promise((r) => setTimeout(r, SCAN_DELAY_MS)); // wait for chart to load
 
-    // Parse available qty from lock error: "0.001234XRP can be used at most"
-    const lockMatch = res.msg?.match(/([\d.]+)XRP can be used at most/i);
-    if (lockMatch) {
-      const available = parseFloat(lockMatch[1]);
-      console.log(
-        `  🔒 Lock active — only ${available} XRP tradeable. Retry ${attempt}/${maxRetries} in ${retryDelayMs / 1000}s...`,
-      );
-      await new Promise((r) => setTimeout(r, retryDelayMs));
+  const ohlcv = await data.getOHLCV({ count: 30 });
+  if (!ohlcv.success || !ohlcv.bars?.length) return null;
+
+  return ohlcv.bars.map((b) => ({
+    ts: b.time,
+    open: b.open,
+    high: b.high,
+    low: b.low,
+    close: b.close,
+    vol: b.volume,
+  }));
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+async function main() {
+  console.log(`\n📈 Options Scalper — ${rules.strategy.name}`);
+  console.log(`Watchlist: ${watchlist.join(", ")}\n`);
+
+  // ── Step 1: Check VIX regime ─────────────────────────────────
+  console.log("🔍 Checking VIX...");
+  const vixCandles = await getSymbolData("VIX");
+  const vixLevel = vixCandles ? vixCandles[vixCandles.length - 1].close : 20;
+  const regime = getVixRegime(vixLevel);
+  const sizeMultiplier = getSizeMultiplier(regime);
+  const stopLossPct = getStopLossPct(regime);
+  const regimeInfo = vix_filter.regimes[regime];
+
+  console.log(`VIX: ${vixLevel.toFixed(2)} → Regime: ${regime.toUpperCase()}`);
+  console.log(`Action: ${regimeInfo.action}\n`);
+
+  if (regime === "extreme") {
+    console.log("🚫 VIX above 40 — no trades today. Exiting.\n");
+    process.exit(0);
+  }
+
+  // ── Step 2: Check market hours ────────────────────────────────
+  if (!isMarketOpen()) {
+    console.log("🕐 Outside trading hours (9:45 AM – 3:30 PM EST) — exiting.\n");
+    process.exit(0);
+  }
+
+  // ── Step 3: Scan each symbol ──────────────────────────────────
+  const log = [];
+  const tradableSymbols = regime === "high"
+    ? watchlist.filter((s) => ["AMZN", "MSFT"].includes(s)) // high VIX = only most liquid
+    : watchlist.filter((s) => s !== "VIX");
+
+  console.log(`Scanning ${tradableSymbols.length} symbols (VIX regime: ${regime})...\n`);
+
+  for (const symbol of tradableSymbols) {
+    const ts = new Date().toISOString();
+    console.log(`── ${symbol} ──`);
+
+    const candles = await getSymbolData(symbol);
+    if (!candles || candles.length < 22) {
+      console.log(`  ⚠️  Not enough data — skipping\n`);
       continue;
     }
 
-    // Any other error — don't retry
-    return { ok: false, res, soldQty: 0 };
-  }
-  return {
-    ok: false,
-    res: { msg: "Sell lock never lifted after retries" },
-    soldQty: 0,
-  };
-}
+    const { signal, skipReason, rsi, vwap, momentumPct, price } = getSignal(candles);
 
-// ── Main loop ───────────────────────────────────────────────────
-async function main() {
-  console.log(`\n🤖 BTC Scalper — VWAP + RSI(3) + EMA(8)`);
-  console.log(
-    `Symbol: ${SYMBOL} | ${TOTAL_TRADES} trades × ${INTERVAL_MS / 1000}s\n`,
-  );
+    console.log(`  Price: $${price.toFixed(2)} | RSI: ${rsi.toFixed(1)} | VWAP: $${vwap.toFixed(2)} | Momentum: ${momentumPct.toFixed(3)}%`);
 
-  const log = [];
-  let holding = "usdt";
-  let lastBuyXrpQty = 0;
-
-  for (let i = 1; i <= TOTAL_TRADES; i++) {
-    const ts = new Date().toISOString();
-    const candles = await getCandles(SYMBOL, 30);
-    const { signal, last, ema8, rsi3, vwap } = getSignal(candles);
-    const bals = await getBalances();
-
-    console.log(`[${i}/${TOTAL_TRADES}] ${ts}`);
-    console.log(
-      `  Price: $${last.toFixed(4)} | EMA8: ${ema8.toFixed(4)} | RSI3: ${rsi3.toFixed(1)} | VWAP: ${vwap.toFixed(4)}`,
-    );
-    console.log(
-      `  USDT: $${bals.usdt.toFixed(4)} | XRP: ${bals.xrp.toFixed(4)} | Signal: ${signal.toUpperCase()}`,
-    );
-
-    let side, size, label;
     const entry = {
-      tick: i,
       timestamp: ts,
-      price: last,
-      ema8,
-      rsi3,
-      vwap,
+      symbol,
+      price,
+      rsi: parseFloat(rsi.toFixed(2)),
+      vwap: parseFloat(vwap.toFixed(2)),
+      momentumPct: parseFloat(momentumPct.toFixed(4)),
+      vixLevel: parseFloat(vixLevel.toFixed(2)),
+      vixRegime: regime,
       signal,
-      orderPlaced: false,
+      action: null,
     };
 
-    if (signal === "buy" && holding === "usdt" && bals.usdt >= 1) {
-      side = "buy";
-      size = (bals.usdt * 0.9).toFixed(4);
-      label = `BUY XRP with $${size} USDT`;
-      holding = "xrp";
-    } else if (signal === "sell" && holding === "xrp" && lastBuyXrpQty >= 1) {
-      side = "sell";
-      size = (Math.floor(lastBuyXrpQty * 10000) / 10000).toFixed(4);
-      label = `SELL ${size} XRP → USDT`;
-      holding = "usdt";
+    if (signal === "flat" || skipReason) {
+      console.log(`  ⏭  Skip — ${skipReason}\n`);
+      entry.action = "skip";
+      entry.skipReason = skipReason;
     } else {
-      const reason =
-        signal === "flat"
-          ? "no signal — conditions not met"
-          : `signal=${signal} but holding=${holding} (waiting for right side)`;
-      console.log(`  ⏭  Skip — ${reason}\n`);
-      entry.skipped = true;
-      entry.skipReason = reason;
-      log.push(entry);
-      if (i < TOTAL_TRADES)
-        await new Promise((r) => setTimeout(r, INTERVAL_MS));
-      continue;
-    }
+      const instrument = signal === "call" ? "CALL" : "PUT";
+      const direction = signal === "call" ? "bullish" : "bearish";
 
-    console.log(`  → ${label}`);
-    entry.side = side;
-    entry.size = size;
+      console.log(`  ✅ Signal: ${instrument} (${direction})`);
+      console.log(`  📋 Entry: Buy ATM ${instrument} — nearest expiry`);
+      console.log(`  🎯 Exit: +25% profit target | -${stopLossPct}% stop | 5-min time stop`);
+      console.log(`  📏 Size multiplier: ${sizeMultiplier}x (VIX regime: ${regime})`);
 
-    if (side === "buy") {
-      const res = await placeOrder("buy", size);
-      const ok = res.code === "00000";
-      const orderId = res.data?.orderId;
-      entry.orderId = orderId || res.msg;
-      entry.orderPlaced = ok;
+      // ── BROKER EXECUTION PLACEHOLDER ──────────────────────────
+      // Connect your broker API here (Tradier, Schwab, IBKR, etc.)
+      // Example shape:
+      //   await broker.buyOption({ symbol, type: signal, expiry: "0DTE", strike: "ATM" });
+      // ──────────────────────────────────────────────────────────
 
-      if (ok) {
-        console.log(`  ✅ BUY PLACED — ${orderId}`);
-        lastBuyXrpQty = await getOrderFill(orderId);
-        console.log(
-          `  📦 Filled: ${lastBuyXrpQty.toFixed(4)} XRP — waiting for lock to clear...`,
-        );
-        entry.filledQty = lastBuyXrpQty;
-      } else {
-        console.log(`  ❌ Rejected: ${res.msg}`);
-        holding = "usdt";
-      }
-    } else {
-      // Use retry loop — handles BitGet's anti-wash-trading lock automatically
-      const { ok, res, soldQty } = await placeSellWithRetry(lastBuyXrpQty);
-      entry.orderId = res.data?.orderId || res.msg;
-      entry.orderPlaced = ok;
-
-      if (ok) {
-        console.log(
-          `  ✅ SELL PLACED — ${entry.orderId} (${soldQty.toFixed(4)} XRP)`,
-        );
-        lastBuyXrpQty = 0;
-      } else {
-        console.log(`  ❌ Sell failed: ${res.msg}`);
-        holding = "xrp"; // still holding
-      }
+      entry.action = `buy_${signal}`;
+      entry.instrument = `ATM ${instrument}`;
+      entry.sizeMultiplier = sizeMultiplier;
+      entry.profitTargetPct = 25;
+      entry.stopLossPct = stopLossPct;
+      entry.timeStopMinutes = 5;
+      console.log();
     }
 
     log.push(entry);
-
-    if (i < TOTAL_TRADES) {
-      const waitMs =
-        side === "buy" ? Math.max(INTERVAL_MS - 5000, 4000) : INTERVAL_MS;
-      console.log(`  ⏱  Next in ${waitMs / 1000}s...\n`);
-      await new Promise((r) => setTimeout(r, waitMs));
-    }
   }
 
-  const final = await getBalances();
-  const price = await getPrice(SYMBOL);
-  const totalValue = final.usdt + final.xrp * price;
-  console.log(`\n📊 Final:`);
-  console.log(`  USDT: $${final.usdt.toFixed(4)}`);
-  console.log(
-    `  XRP: ${final.xrp.toFixed(4)} (≈$${(final.xrp * price).toFixed(4)})`,
-  );
-  console.log(`  Total est. value: $${totalValue.toFixed(4)}`);
-
-  const placed = log.filter((e) => e.orderPlaced).length;
-  console.log(`\n✅ Done — ${placed}/${TOTAL_TRADES} orders placed.\n`);
-
+  // ── Step 4: Save log ──────────────────────────────────────────
   const existing = existsSync("safety-check-log.json")
     ? JSON.parse(readFileSync("safety-check-log.json", "utf8"))
     : [];
-  writeFileSync(
-    "safety-check-log.json",
-    JSON.stringify([...existing, ...log], null, 2),
-  );
+  writeFileSync("safety-check-log.json", JSON.stringify([...existing, ...log], null, 2));
+
+  const signals = log.filter((e) => e.action?.startsWith("buy_"));
+  console.log(`\n📊 Scan complete — ${signals.length} signal(s) across ${log.length} symbols.`);
+  if (signals.length) {
+    console.log("Signals:");
+    signals.forEach((e) => console.log(`  ${e.symbol}: ${e.instrument} | RSI ${e.rsi} | Momentum ${e.momentumPct}%`));
+  }
+  console.log();
 }
 
 main().catch((err) => {


### PR DESCRIPTION
- rules.json: Replace BTCUSDT watchlist with MU, AMZN, PLTR, SOFI, NFLX, MSFT, APP, AMD, VIX; add full options scalping logic with RSI/VWAP/volume/momentum filters, VIX regime gating (5 tiers), market hours restrictions, and per-symbol guidance
- scalper-run.js: Full rewrite — removes all BitGet/XRP/crypto code; now reads rules.json, checks VIX regime first, loops watchlist via TradingView core modules, applies options signal logic, logs decisions with broker execution placeholder
- rules.example.json: Updated from BTC/ETH/SOL crypto example to options scalper format
- safety-check-log.json: Cleared 13 stale crypto entries; replaced with strategy migration record and full settings confirmation for the new stock options config