### PR TITLE
Fix MSIX detection and launch for Windows Store TradingView installs

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,9 +17,11 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs (WindowsApps is permission-restricted, use PowerShell)
 if "%TV_EXE%"=="" (
-    for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
+    for /f "tokens=*" %%i in ('powershell -NoProfile -Command "(Get-AppxPackage -Name 'TradingView*').InstallLocation + '\TradingView.exe'" 2^>nul') do (
+        if exist "%%i" set "TV_EXE=%%i"
+    )
 )
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('where TradingView.exe 2^>nul') do set "TV_EXE=%%i"
@@ -36,7 +38,14 @@ if "%TV_EXE%"=="" (
 
 echo Found TradingView at: %TV_EXE%
 echo Starting with --remote-debugging-port=%PORT%...
-start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+
+REM MSIX apps in WindowsApps require Start-Process to honour CLI flags
+echo "%TV_EXE%" | findstr /i "WindowsApps" >nul 2>&1
+if %errorlevel% equ 0 (
+    powershell -NoProfile -Command "Start-Process '%TV_EXE%' -ArgumentList '--remote-debugging-port=%PORT%'"
+) else (
+    start "" "%TV_EXE%" --remote-debugging-port=%PORT%
+)
 
 echo Waiting for CDP to become available...
 timeout /t 5 /nobreak >nul


### PR DESCRIPTION
## What changed
- **Detection**: Replaced the permission-restricted `dir /s /b` on `WindowsApps` with `Get-AppxPackage` via PowerShell, which correctly reads MSIX install paths.
- **Launch**: Added a check — if the exe path contains `WindowsApps`, use `Start-Process` via PowerShell instead of `start ""`, so `--remote-debugging-port` is actually passed through to the Electron app.

## Why
Windows Store (MSIX) installs of TradingView live in `C:\Program Files\WindowsApps\`, which is ACL-restricted and not listable by normal batch `dir` commands. Additionally, MSIX apps launched with `start ""` silently ignore CLI flags — `Start-Process` is required for the flags to be honoured.

Verified working on TradingView 3.0.0 (Store install) — CDP comes up correctly on port 9222.

## Reviewer notes
No logic changes for non-MSIX installs — the original `start ""` path is preserved for traditional installs.