### PR TITLE
Add tv_launch_browser — connect MCP to TradingView website via Chrome/Edge

### DIFF
--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -7,7 +7,7 @@ register('status', {
 });
 
 register('launch', {
-  description: 'Launch TradingView with CDP enabled',
+  description: 'Launch TradingView Desktop app with CDP enabled',
   options: {
     port: { type: 'string', short: 'p', description: 'CDP port (default 9222)' },
     'no-kill': { type: 'boolean', description: 'Do not kill existing instances' },
@@ -15,5 +15,19 @@ register('launch', {
   handler: (opts) => core.launch({
     port: opts.port ? Number(opts.port) : undefined,
     kill_existing: !opts['no-kill'],
+  }),
+});
+
+register('launch-browser', {
+  description: 'Launch Chrome or Edge and open TradingView website with CDP enabled',
+  options: {
+    port: { type: 'string', short: 'p', description: 'CDP port (default 9222)' },
+    browser: { type: 'string', short: 'b', description: 'Browser: chrome (default) or edge' },
+    profile: { type: 'string', description: 'Custom user-data-dir path for browser profile' },
+  },
+  handler: (opts) => core.launchBrowser({
+    port: opts.port ? Number(opts.port) : undefined,
+    browser: opts.browser,
+    profile: opts.profile,
   }),
 });

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -159,6 +159,155 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
+export async function launchBrowser({ port, browser: preferredBrowser, profile } = {}) {
+  const cdpPort = port || 9222;
+  const platform = process.platform;
+  const tvUrl = 'https://www.tradingview.com/chart/';
+
+  // --- Persistent profile directory (keeps TradingView login cookies across sessions) ---
+  // Uses a dedicated dir so it never conflicts with a user's normal Chrome session.
+  const defaultProfileDir = platform === 'win32'
+    ? `${process.env.LOCALAPPDATA}\\TradingView-MCP\\browser-profile`
+    : `${process.env.HOME}/.tradingview-mcp/browser-profile`;
+  const profileDir = profile || defaultProfileDir;
+
+  // --- Ensure profile directory exists ---
+  const { mkdirSync } = await import('fs');
+  try { mkdirSync(profileDir, { recursive: true }); } catch { /* already exists */ }
+
+  // --- Check if CDP is already live on the port (avoid double-launch) ---
+  const http = await import('http');
+  const cdpAlreadyLive = await new Promise((resolve) => {
+    http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+      let data = '';
+      res.on('data', chunk => data += chunk);
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)); } catch { resolve(null); }
+      });
+    }).on('error', () => resolve(null));
+  });
+
+  if (cdpAlreadyLive) {
+    // CDP already running — just open the TradingView URL in a new tab if needed
+    const targets = await new Promise((resolve) => {
+      http.get(`http://localhost:${cdpPort}/json/list`, (res) => {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => { try { resolve(JSON.parse(data)); } catch { resolve([]); } });
+      }).on('error', () => resolve([]));
+    });
+    const hasTVTab = targets.some(t => /tradingview\.com\/chart/i.test(t.url));
+    return {
+      success: true,
+      already_running: true,
+      cdp_port: cdpPort,
+      browser: cdpAlreadyLive.Browser,
+      tradingview_tab_open: hasTVTab,
+      profile_dir: profileDir,
+      note: hasTVTab
+        ? 'Browser with TradingView already running and connected. Run tv_health_check.'
+        : `Browser already running but no TradingView chart tab found. Open ${tvUrl} in that browser window.`,
+    };
+  }
+
+  // --- Find browser binary ---
+  const chromeCandidates = {
+    win32: [
+      `${process.env.LOCALAPPDATA}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${process.env.PROGRAMFILES}\\Google\\Chrome\\Application\\chrome.exe`,
+      `${process.env['PROGRAMFILES(X86)']}\\Google\\Chrome\\Application\\chrome.exe`,
+    ],
+    darwin: [
+      '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+      `${process.env.HOME}/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
+    ],
+    linux: ['google-chrome', 'google-chrome-stable', 'chromium-browser', 'chromium'],
+  };
+
+  const edgeCandidates = {
+    win32: [
+      `${process.env['PROGRAMFILES(X86)']}\\Microsoft\\Edge\\Application\\msedge.exe`,
+      `${process.env.PROGRAMFILES}\\Microsoft\\Edge\\Application\\msedge.exe`,
+    ],
+    darwin: [
+      '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+    ],
+    linux: ['microsoft-edge', 'microsoft-edge-stable'],
+  };
+
+  const allCandidates = preferredBrowser === 'edge'
+    ? [...(edgeCandidates[platform] || []), ...(chromeCandidates[platform] || [])]
+    : [...(chromeCandidates[platform] || []), ...(edgeCandidates[platform] || [])];
+
+  let browserPath = null;
+  for (const p of allCandidates) {
+    if (!p) continue;
+    if (p.includes('/') || p.includes('\\')) {
+      if (existsSync(p)) { browserPath = p; break; }
+    } else {
+      try {
+        const cmd = platform === 'win32' ? `where "${p}"` : `which "${p}"`;
+        const found = execSync(cmd, { timeout: 3000 }).toString().trim().split('\n')[0];
+        if (found && existsSync(found)) { browserPath = found; break; }
+      } catch { /* not found */ }
+    }
+  }
+
+  if (!browserPath) {
+    throw new Error(
+      `No Chrome or Edge browser found on ${platform}. ` +
+      `Install Google Chrome or Microsoft Edge, then try again. ` +
+      `Or launch manually: "chrome.exe" --remote-debugging-port=${cdpPort} --user-data-dir="${profileDir}" "${tvUrl}"`
+    );
+  }
+
+  // --- Launch browser with persistent profile and remote debugging ---
+  const isFirstRun = !existsSync(`${profileDir}/Default/Cookies`);
+  const args = [
+    `--remote-debugging-port=${cdpPort}`,
+    `--user-data-dir=${profileDir}`,
+    '--no-first-run',
+    '--no-default-browser-check',
+    tvUrl,
+  ];
+
+  const child = spawn(browserPath, args, { detached: true, stdio: 'ignore' });
+  child.unref();
+
+  // --- Wait for CDP to become available ---
+  for (let i = 0; i < 20; i++) {
+    await new Promise(r => setTimeout(r, 1000));
+    const info = await new Promise((resolve) => {
+      http.get(`http://localhost:${cdpPort}/json/version`, (res) => {
+        let data = '';
+        res.on('data', chunk => data += chunk);
+        res.on('end', () => { try { resolve(JSON.parse(data)); } catch { resolve(null); } });
+      }).on('error', () => resolve(null));
+    });
+    if (info) {
+      return {
+        success: true, platform, binary: browserPath, pid: child.pid,
+        cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+        browser: info.Browser,
+        profile_dir: profileDir,
+        tradingview_url: tvUrl,
+        first_run: isFirstRun,
+        note: isFirstRun
+          ? 'First launch: log in to TradingView in the browser window. Your session will be saved for future launches.'
+          : 'Browser launched with saved session — you should already be logged in. Run tv_health_check.',
+      };
+    }
+  }
+
+  return {
+    success: true, platform, binary: browserPath, pid: child.pid,
+    cdp_port: cdpPort, cdp_ready: false,
+    profile_dir: profileDir,
+    warning: 'Browser launched but CDP not responding yet. Try tv_health_check in a few seconds.',
+    tradingview_url: tvUrl,
+  };
+}
+
 export async function launch({ port, kill_existing } = {}) {
   const cdpPort = port || 9222;
   const killFirst = kill_existing !== false;

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -5,6 +5,42 @@ import * as core from '../core/health.js';
 export function registerHealthTools(server) {
   server.tool('tv_health_check', 'Check CDP connection to TradingView and return current chart state', {}, async () => {
     try { return jsonResult(await core.healthCheck()); }
+    catch (err) { return jsonResult({ success: false, error: err.message, hint: 'TradingView is not running with CDP enabled. Use tv_launch (Desktop app) or tv_launch_browser (Chrome/Edge with TradingView website) to start it.' }, true); }
+  });
+
+  server.tool('tv_discover', 'Report which known TradingView API paths are available and their methods', {}, async () => {
+    try { return jsonResult(await core.discover()); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('tv_ui_state', 'Get current UI state: which panels are open, what buttons are visible/enabled/disabled', {}, async () => {
+    try { return jsonResult(await core.uiState()); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('tv_launch_browser', 'Launch Chrome or Edge browser and open TradingView website (tradingview.com/chart) with CDP enabled. Use this instead of tv_launch when you want the web version rather than the Desktop app.', {
+    port: z.coerce.number().optional().describe('CDP port (default 9222)'),
+    browser: z.enum(['chrome', 'edge']).optional().describe('Preferred browser: "chrome" (default) or "edge"'),
+    profile: z.string().optional().describe('Custom browser user-data-dir path (to use a specific Chrome profile)'),
+  }, async ({ port, browser, profile }) => {
+    try { return jsonResult(await core.launchBrowser({ port, browser, profile })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+
+  server.tool('tv_launch', 'Launch TradingView Desktop app with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux. For the web version, use tv_launch_browser instead.', {
+    port: z.coerce.number().optional().describe('CDP port (default 9222)'),
+    kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
+  }, async ({ port, kill_existing }) => {
+    try { return jsonResult(await core.launch({ port, kill_existing })); }
+    catch (err) { return jsonResult({ success: false, error: err.message }, true); }
+  });
+}import { z } from 'zod';
+import { jsonResult } from './_format.js';
+import * as core from '../core/health.js';
+
+export function registerHealthTools(server) {
+  server.tool('tv_health_check', 'Check CDP connection to TradingView and return current chart state', {}, async () => {
+    try { return jsonResult(await core.healthCheck()); }
     catch (err) { return jsonResult({ success: false, error: err.message, hint: 'TradingView is not running with CDP enabled. Use the tv_launch tool to start it automatically.' }, true); }
   });
 


### PR DESCRIPTION
## Summary

- Adds `tv_launch_browser` MCP tool and `launchBrowser()` core function to connect the MCP server to the TradingView **website** (tradingview.com/chart) via Chrome or Edge, as an alternative to the Desktop app
- - Uses a **persistent browser profile** (`AppData/Local/TradingView-MCP/browser-profile` on Windows, `~/.tradingview-mcp/browser-profile` elsewhere) so TradingView login cookies survive restarts — log in once, stay logged in
- - **Idempotent**: if CDP is already live on port 9222, returns `already_running: true` without spawning a second browser
- - Auto-detects Chrome then Edge; accepts `browser: "edge"` to prefer Edge
- - Accepts optional `profile` param to override the profile directory
- - Adds `tv launch-browser` CLI command with `--port`, `--browser`, `--profile` flags
- - Updates `tv_health_check` error hint to mention `tv_launch_browser`
## Test plan

- [x] Run `tv_launch_browser` — Chrome opens at tradingview.com/chart/
- [x] - [ ] Log in to TradingView (first run only)
- [x] - [ ] Run `tv_health_check` — confirms `api_available: true` and shows current symbol
- [x] - [ ] Close browser, run `tv_launch_browser` again — auto-logged in (no login prompt)
- [x] - [ ] Run `tv_launch_browser` while browser is already open — returns `already_running: true`
- [x] - [ ] Run `tv launch-browser --browser edge` — Edge opens instead