### PR TITLE
Add chart analysis strategy — CLI script + Claude skill

### DIFF
--- a/chart-strategy.js
+++ b/chart-strategy.js
@@ -1,0 +1,193 @@
+#!/usr/bin/env node
+/**
+ * chart-strategy.js — Multi-timeframe chart analysis via TradingView MCP CLI
+ *
+ * Usage:
+ *   node chart-strategy.js BAC          # analyze Bank of America
+ *   node chart-strategy.js ES1!         # analyze E-mini S&P
+ *   node chart-strategy.js AAPL D       # AAPL on daily timeframe
+ *
+ * What it does:
+ *   1. Switches chart to the requested symbol + timeframe
+ *   2. Pulls current quote, OHLCV summary, and indicator readings
+ *   3. Reads Pine-drawn levels, labels, and tables (if any custom indicators present)
+ *   4. Captures a screenshot
+ *   5. Outputs a structured JSON report to stdout + saves to reports/
+ */
+
+import { execSync } from "child_process";
+import { mkdirSync, writeFileSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = `node ${join(__dirname, "src", "cli", "index.js")}`;
+
+// ── Helpers ────────────────────────────────────────────────────────
+function tv(cmd) {
+  try {
+    const raw = execSync(`${CLI} ${cmd}`, {
+      encoding: "utf8",
+      timeout: 15000,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    return JSON.parse(raw);
+  } catch (e) {
+    return { success: false, error: e.message.slice(0, 200) };
+  }
+}
+
+function log(msg) {
+  process.stderr.write(msg + "\n");
+}
+
+// ── Main ───────────────────────────────────────────────────────────
+const symbol = process.argv[2] || "BAC";
+const timeframe = process.argv[3] || "D";
+
+log(`\n── Chart Strategy Report ──`);
+log(`Symbol: ${symbol} | Timeframe: ${timeframe}\n`);
+
+// Step 1 — Health check
+log("1. Checking TradingView connection...");
+const health = tv("status");
+if (!health.success) {
+  log("   TradingView is not connected. Launch it with:");
+  log('   TradingView.exe --remote-debugging-port=9222');
+  log("   Then re-run this script.");
+  process.exit(1);
+}
+log("   Connected.");
+
+// Step 2 — Switch symbol and timeframe
+log(`2. Setting chart to ${symbol} / ${timeframe}...`);
+const symResult = tv(`symbol ${symbol}`);
+if (!symResult.success) {
+  log(`   Failed to set symbol: ${symResult.error}`);
+  process.exit(1);
+}
+// Small pause for chart to load
+execSync("ping -n 2 127.0.0.1 > NUL", { stdio: "pipe" }); // ~1s delay on Windows
+tv(`timeframe ${timeframe}`);
+execSync("ping -n 2 127.0.0.1 > NUL", { stdio: "pipe" });
+log("   Done.");
+
+// Step 3 — Gather data (parallel-safe since each is a read)
+log("3. Gathering data...");
+
+const quote = tv("quote");
+const ohlcv = tv("ohlcv --summary");
+const values = tv("values");
+const state = tv("state");
+
+// Pine graphics (only useful if custom indicators are on chart)
+const pineLines = tv("data lines");
+const pineLabels = tv("data labels");
+const pineTables = tv("data tables");
+
+log("   Data collected.");
+
+// Step 4 — Screenshot
+log("4. Taking screenshot...");
+const screenshot = tv("screenshot");
+log(`   ${screenshot.success ? screenshot.path || "Saved" : "Skipped (no connection)"}`);
+
+// Step 5 — Build report
+log("5. Building report...\n");
+
+const report = {
+  generated: new Date().toISOString(),
+  symbol,
+  timeframe,
+  quote: quote.success ? strip(quote) : null,
+  ohlcv_summary: ohlcv.success ? strip(ohlcv) : null,
+  indicators: values.success ? strip(values) : null,
+  chart_state: state.success ? strip(state) : null,
+  pine_levels: pineLines.success ? strip(pineLines) : null,
+  pine_labels: pineLabels.success ? strip(pineLabels) : null,
+  pine_tables: pineTables.success ? strip(pineTables) : null,
+  screenshot: screenshot.success ? screenshot.path || null : null,
+};
+
+// Save report
+const reportsDir = join(__dirname, "reports");
+if (!existsSync(reportsDir)) mkdirSync(reportsDir, { recursive: true });
+const filename = `${symbol.replace(/[^a-zA-Z0-9]/g, "_")}_${timeframe}_${Date.now()}.json`;
+const filepath = join(reportsDir, filename);
+writeFileSync(filepath, JSON.stringify(report, null, 2));
+log(`Report saved: reports/${filename}`);
+
+// Print summary to stdout
+printSummary(report);
+
+// ── Formatting ─────────────────────────────────────────────────────
+function strip(obj) {
+  const { success, ...rest } = obj;
+  return rest;
+}
+
+function printSummary(r) {
+  console.log(`\n${"═".repeat(50)}`);
+  console.log(`  ${r.symbol} — ${r.timeframe} Chart Report`);
+  console.log(`${"═".repeat(50)}`);
+
+  if (r.quote) {
+    const q = r.quote;
+    const price = q.last || q.lp || q.close || "N/A";
+    const change = q.ch != null ? `${q.ch > 0 ? "+" : ""}${q.ch}` : "";
+    const changePct = q.chp != null ? ` (${q.chp > 0 ? "+" : ""}${q.chp}%)` : "";
+    console.log(`\n  Price: $${price} ${change}${changePct}`);
+    if (q.open) console.log(`  Open: $${q.open}  High: $${q.high_price || q.high || "—"}  Low: $${q.low_price || q.low || "—"}`);
+    if (q.volume) console.log(`  Volume: ${Number(q.volume).toLocaleString()}`);
+  }
+
+  if (r.ohlcv_summary) {
+    console.log(`\n  OHLCV Summary:`);
+    const s = r.ohlcv_summary;
+    if (s.high) console.log(`    Range: $${s.low} — $${s.high}`);
+    if (s.avg_volume) console.log(`    Avg Volume: ${Number(s.avg_volume).toLocaleString()}`);
+    if (s.change_pct != null) console.log(`    Change: ${s.change_pct}%`);
+  }
+
+  if (r.indicators && typeof r.indicators === "object") {
+    const entries = Object.entries(r.indicators).filter(([k]) => k !== "error");
+    if (entries.length > 0) {
+      console.log(`\n  Indicators:`);
+      for (const [name, val] of entries) {
+        if (typeof val === "object") {
+          console.log(`    ${name}:`);
+          for (const [k, v] of Object.entries(val)) {
+            console.log(`      ${k}: ${v}`);
+          }
+        } else {
+          console.log(`    ${name}: ${val}`);
+        }
+      }
+    }
+  }
+
+  if (r.pine_levels) {
+    const levels = Array.isArray(r.pine_levels) ? r.pine_levels : r.pine_levels.levels || [];
+    if (levels.length > 0) {
+      console.log(`\n  Key Levels (from indicators):`);
+      levels.slice(0, 10).forEach((l) => {
+        const label = l.label || l.name || "";
+        console.log(`    ${label ? label + ": " : ""}$${l.price || l.value || l}`);
+      });
+    }
+  }
+
+  if (r.pine_labels) {
+    const labels = Array.isArray(r.pine_labels) ? r.pine_labels : r.pine_labels.labels || [];
+    if (labels.length > 0) {
+      console.log(`\n  Chart Labels:`);
+      labels.slice(0, 8).forEach((l) => {
+        console.log(`    ${l.text || l}`);
+      });
+    }
+  }
+
+  console.log(`\n${"═".repeat(50)}`);
+  console.log(`  Report: reports/${filename}`);
+  console.log(`${"═".repeat(50)}\n`);
+}

--- a/skills/chart-analyze
+++ b/skills/chart-analyze
@@ -1,0 +1,38 @@
+---
+description: Analyze the current chart — pulls quote, indicators, levels, and OHLCV summary into a structured trading report.
+user_invocable: true
+---
+
+Analyze the current TradingView chart. Follow these steps exactly:
+
+1. **Get chart state** — call `chart_get_state` to learn the current symbol, timeframe, and active indicators.
+
+2. **Pull price data** — call `quote_get` for the live price, then `data_get_ohlcv` with `summary: true` for recent price action stats.
+
+3. **Read indicators** — call `data_get_study_values` to get current readings from all visible indicators (RSI, MACD, EMAs, etc.).
+
+4. **Read custom levels** — call `data_get_pine_lines` for horizontal levels and `data_get_pine_labels` for labeled annotations from Pine indicators.
+
+5. **Screenshot** — call `capture_screenshot` for visual reference.
+
+6. **Synthesize** — Present a structured report:
+
+   **[SYMBOL] — [TIMEFRAME] Report**
+
+   **Price Action**
+   - Current price, daily change, range
+   - OHLCV summary stats (high, low, avg volume)
+
+   **Indicator Readings**
+   - List each indicator with its current value and what it suggests (bullish/bearish/neutral)
+
+   **Key Levels**
+   - Support and resistance levels from Pine drawings
+   - Any labeled levels (settlement, pivots, etc.)
+
+   **Bias**
+   - Overall lean based on the weight of evidence: Bullish / Bearish / Neutral
+   - Confidence: High / Medium / Low
+   - Key factors driving the bias
+
+Keep the report concise — facts and readings, not speculation. If an indicator is ambiguous, say so.


### PR DESCRIPTION
## Summary
- Adds a reusable chart analysis workflow on top of the existing TradingView MCP tools.
- **chart-strategy.js** — standalone Node CLI (`node chart-strategy.js <SYMBOL> [TIMEFRAME]`). Switches the live chart, pulls quote + OHLCV summary + indicator values + Pine lines/labels/tables, captures a screenshot, and writes a structured JSON report to `reports/`.
- **skills/chart-analyze** — Claude Code skill that performs the same analysis interactively using the MCP tools directly (`chart_get_state` → `quote_get` → `data_get_ohlcv` → `data_get_study_values` → `data_get_pine_lines` → `data_get_pine_labels` → `capture_screenshot`), then outputs a structured bias report (Price Action / Indicators / Key Levels / Bias + Confidence).

## Why
The repo already has a scalper loop and a performance-analyst agent, but no general-purpose "analyze whatever is on the chart right now" entry point. This fills that gap for both programmatic (CLI) and conversational (skill) use.

## Notes for reviewer
- `chart-strategy.js` shells out to `src/cli/index.js` for each MCP call, so it inherits the existing CDP connection behavior — no new dependencies.
- Reports are written to `reports/<SYMBOL>_<TF>_<timestamp>.json`. You may want to `.gitignore` that directory.
- The skill mirrors the rules already documented in `CLAUDE.md` (uses `summary: true` on OHLCV, deduped Pine data) to stay within the context-size guidance.
- Opened as draft — no functional tests added for the new files yet.

## Test plan
- [ ] Launch TradingView with CDP (`scripts/launch_tv_debug.bat` on Windows)
- [ ] Run `node chart-strategy.js BAC D` — confirm JSON report lands in `reports/`
- [ ] Invoke the chart-analyze skill interactively in Claude Code — confirm the structured bias report is produced
- [ ] Verify no regressions in the existing scalper / CLI tools