### PR TITLE
fix: add Windows Store install path to tv_launch search list

### DIFF
--- a/src/core/health.js
+++ b/src/core/health.js
@@ -173,6 +173,7 @@ export async function launch({ port, kill_existing } = {}) {
       `${process.env.LOCALAPPDATA}\\TradingView\\TradingView.exe`,
       `${process.env.PROGRAMFILES}\\TradingView\\TradingView.exe`,
       `${process.env['PROGRAMFILES(X86)']}\\TradingView\\TradingView.exe`,
+      `C:\\Program Files\\WindowsApps\\TradingView.Desktop_3.0.0.7652_x64__n534cwy3pjxzj\\TradingView.exe`,
     ],
     linux: [
       '/opt/TradingView/tradingview',


### PR DESCRIPTION
## What

Adds the Microsoft Store install path for TradingView Desktop to the  search list in , so  auto-detects it without needing a manual path.

## Why

TradingView installed via the Windows Store lands in:
```
C:\Program Files\WindowsApps\TradingView.Desktop_<version>_x64__<id>\TradingView.exe
```
This path is not covered by the existing three search locations (LOCALAPPDATA, PROGRAMFILES, PROGRAMFILES(X86)), so  reported "TradingView not found" for Store installs on Windows.

## Changes

-  - added  to the  paths array

## Notes for reviewer

The version string in the path () will change with Store updates. A more robust follow-up would be to glob  instead of hardcoding the version, but this patch unblocks Store users today.