### PR TITLE
Fix Windows MSIX/Microsoft Store TradingView detection in launch_tv_debug.bat

### DIFF
--- a/scripts/launch_tv_debug.bat
+++ b/scripts/launch_tv_debug.bat
@@ -17,7 +17,14 @@ if exist "%LOCALAPPDATA%\TradingView\TradingView.exe" set "TV_EXE=%LOCALAPPDATA%
 if exist "%PROGRAMFILES%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES%\TradingView\TradingView.exe"
 if exist "%PROGRAMFILES(x86)%\TradingView\TradingView.exe" set "TV_EXE=%PROGRAMFILES(x86)%\TradingView\TradingView.exe"
 
-REM Check MSIX / Windows Store installs
+REM Check MSIX / Windows Store installs via AppX manifest (works without admin)
+if "%TV_EXE%"=="" (
+    for /f "delims=" %%i in ('powershell -NoProfile -Command "(Get-AppxPackage *TradingView* -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty InstallLocation)"') do (
+        if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
+    )
+)
+
+REM Fallback: brute-force WindowsApps dir scan (only works in elevated shell)
 if "%TV_EXE%"=="" (
     for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
 )
@@ -27,7 +34,7 @@ if "%TV_EXE%"=="" (
 
 if "%TV_EXE%"=="" (
     echo Error: TradingView not found.
-    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, WindowsApps
+    echo Checked: %%LOCALAPPDATA%%\TradingView, %%PROGRAMFILES%%\TradingView, AppX ^(Microsoft Store^), WindowsApps
     echo.
     echo If installed elsewhere, run manually:
     echo   "C:\path\to\TradingView.exe" --remote-debugging-port=%PORT%


### PR DESCRIPTION
## Summary

Fixes detection of TradingView Desktop installs from the Microsoft Store (MSIX) on Windows. With the current script, users on Store builds see `Error: TradingView not found` even though the app is installed and runnable.

## Why the existing check fails

The script attempts to find Store installs via:

```bat
for /f "tokens=*" %%i in ('dir /s /b "%PROGRAMFILES%\WindowsApps\TradingView*\TradingView.exe" 2^>nul') do set "TV_EXE=%%i"
```

`%PROGRAMFILES%\WindowsApps` has an ACL that denies list access to regular users — only `TrustedInstaller` can enumerate it. In a non-elevated shell, `dir /s /b` fails with "Access is denied" before it can recurse, the `2^>nul` swallows the error, and the for-loop produces nothing. The fallback `where TradingView.exe` also misses because Store apps don't register on `PATH`.

## Fix

Add a primary MSIX detector using `Get-AppxPackage`, which queries the AppX manifest and returns `InstallLocation` without needing folder ACL access or admin rights:

```bat
for /f "delims=" %%i in ('powershell -NoProfile -Command "(Get-AppxPackage *TradingView* -ErrorAction SilentlyContinue | Select-Object -First 1 -ExpandProperty InstallLocation)"') do (
    if exist "%%i\TradingView.exe" set "TV_EXE=%%i\TradingView.exe"
)
```

The original `dir /s /b` block stays as a fallback for elevated shells where it would still work.

Also escapes parens in the updated `Checked:` error message — `AppX (Microsoft Store)` would otherwise close the enclosing `if` block prematurely and produce "WindowsApps was unexpected at this time."

## Test plan

- [x] Reproduced original bug on Windows 11 with Store-installed TradingView (`TradingView.Desktop_3.1.0.7818_x64__n534cwy3pjxzj`) in non-elevated `cmd` — original script reports "not found"
- [x] After patch, script resolves the install path via `Get-AppxPackage`, launches with `--remote-debugging-port=9222`, and CDP comes up at `http://localhost:9222/json/version`
- [x] `tv_health_check` MCP tool reports `cdp_connected: true`, `api_available: true`
- [ ] Verify still works with classic (non-Store) installs at `%LOCALAPPDATA%\TradingView` and `%PROGRAMFILES%\TradingView` — those code paths are unchanged

## Notes for reviewer

- No new dependencies — `powershell.exe` ships with all supported Windows versions
- `Get-AppxPackage` returns nothing on systems without the cmdlet (none in practice on Win10/11), so the existing fallbacks still run
- The fix is Windows-only; `launch_tv_debug_mac.sh` and `launch_tv_debug_linux.sh` are untouched

Generated with [Claude Code](https://claude.com/claude-code)
