### PR TITLE
fix: use evaluateAsync for createStudy to prevent race condition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
         "chrome-remote-interface": "^0.33.2"
+      },
+      "bin": {
+        "tv": "src/cli/index.js"
       }
     },
     "node_modules/@hono/node-server": {

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -78,10 +78,10 @@ export async function manageIndicator({ action, indicator, entity_id, inputs: in
   if (action === 'add') {
     const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
     const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
-    await evaluate(`
+    await evaluateAsync(`
       (function() {
         var chart = ${CHART_API};
-        chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
+        return chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
       })()
     `);
     await new Promise(r => setTimeout(r, 1500));


### PR DESCRIPTION
## Summary

- Switches `chart.createStudy(...)` from `evaluate` to `evaluateAsync` so the call returns a resolved promise rather than a pending one
- Adds `return` inside the IIFE so the caller receives the study result
- Updates `package-lock.json` to reflect current dependency state after `npm install`

## Why

The `evaluate` call was fire-and-forget — it didn't wait for `createStudy` to complete before continuing. This caused a race condition where the 1500ms `setTimeout` below it could fire before the study was actually added to the chart, leading to missed indicators. Switching to `evaluateAsync` ensures the promise resolves before execution continues.

## Testing

Tested locally with TradingView Desktop — indicators now reliably appear after `manageIndicator({ action: 'add', ... })` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)