### PR TITLE
Fix `alert create` by calling the pricealerts API directly

### DIFF
--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,75 +1,98 @@
 /**
  * Core alert logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync } from '../connection.js';
+
+const CONDITION_TYPE = {
+  crossing: 'cross',
+  greater_than: 'greater',
+  less_than: 'less',
+};
 
 export async function create({ condition, price, message }) {
-  const opened = await evaluate(`
-    (function() {
-      var btn = document.querySelector('[aria-label="Create Alert"]')
-        || document.querySelector('[data-name="alerts"]');
-      if (btn) { btn.click(); return true; }
-      return false;
-    })()
-  `);
-
-  if (!opened) {
-    const client = await getClient();
-    await client.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 1, key: 'a', code: 'KeyA', windowsVirtualKeyCode: 65 });
-    await client.Input.dispatchKeyEvent({ type: 'keyUp', key: 'a', code: 'KeyA' });
+  const ctype = CONDITION_TYPE[condition] || 'cross';
+  if (!Number.isFinite(price)) {
+    return { success: false, error: `Invalid price: ${price}`, source: 'pricealerts_api' };
   }
 
-  await new Promise(r => setTimeout(r, 1000));
-
-  const priceSet = await evaluate(`
+  // Resolve current chart symbol and the logged-in username (both required for the API)
+  const ctx = await evaluate(`
     (function() {
-      var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
-      for (var i = 0; i < inputs.length; i++) {
-        var label = inputs[i].closest('[class*="row"]')?.querySelector('[class*="label"]');
-        if (label && /value|price/i.test(label.textContent)) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-          nativeSet.call(inputs[i], '${price}');
-          inputs[i].dispatchEvent(new Event('input', { bubbles: true }));
-          inputs[i].dispatchEvent(new Event('change', { bubbles: true }));
-          return true;
-        }
-      }
-      if (inputs.length > 0) {
-        var nativeSet = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-        nativeSet.call(inputs[0], '${price}');
-        inputs[0].dispatchEvent(new Event('input', { bubbles: true }));
-        return true;
-      }
-      return false;
+      var wv = window.TradingViewApi && window.TradingViewApi._activeChartWidgetWV && window.TradingViewApi._activeChartWidgetWV.value();
+      var sym = wv && typeof wv.symbol === 'function' ? wv.symbol() : null;
+      var username = (window.user && window.user.username) || null;
+      return { symbol: sym, username: username };
     })()
   `);
-
-  if (message) {
-    await evaluate(`
-      (function() {
-        var textarea = document.querySelector('[class*="alert"] textarea')
-          || document.querySelector('textarea[placeholder*="message"]');
-        if (textarea) {
-          var nativeSet = Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set;
-          nativeSet.call(textarea, ${JSON.stringify(message)});
-          textarea.dispatchEvent(new Event('input', { bubbles: true }));
-        }
-      })()
-    `);
+  if (!ctx?.symbol) {
+    return { success: false, error: 'Could not resolve chart symbol', source: 'pricealerts_api' };
+  }
+  if (!ctx?.username) {
+    return { success: false, error: 'Could not resolve TradingView username', source: 'pricealerts_api' };
   }
 
-  await new Promise(r => setTimeout(r, 500));
-  const created = await evaluate(`
-    (function() {
-      var btns = document.querySelectorAll('button[data-name="submit"], button');
-      for (var i = 0; i < btns.length; i++) {
-        if (/^create$/i.test(btns[i].textContent.trim())) { btns[i].click(); return true; }
-      }
-      return false;
-    })()
+  const expiration = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString();
+  const defaultMessage = `${ctx.symbol.split(':').pop()} ${ctype === 'cross' ? 'Crossing' : ctype} ${price}`;
+  const payload = {
+    payload: {
+      symbol: `=${JSON.stringify({ adjustment: 'splits', 'currency-id': 'USD', symbol: ctx.symbol })}`,
+      resolution: '1',
+      message: message || defaultMessage,
+      sound_file: null,
+      sound_duration: 0,
+      popup: true,
+      expiration,
+      auto_deactivate: false,
+      email: false,
+      sms_over_email: false,
+      mobile_push: true,
+      web_hook: null,
+      name: null,
+      conditions: [{
+        type: ctype,
+        frequency: 'on_first_fire',
+        series: [
+          { type: 'barset' },
+          { type: 'value', value: price },
+        ],
+        resolution: '1',
+      }],
+      active: true,
+      ignore_warnings: true,
+    },
+  };
+
+  const url = `https://pricealerts.tradingview.com/create_alert?log_username=${encodeURIComponent(ctx.username)}`;
+  const result = await evaluateAsync(`
+    fetch(${JSON.stringify(url)}, {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+      body: ${JSON.stringify(JSON.stringify(payload))}
+    })
+    .then(function(r){ return r.json().then(function(d){ return { status: r.status, data: d }; }); })
+    .catch(function(e){ return { error: e.message }; })
   `);
 
-  return { success: !!created, price, condition, message: message || '(none)', price_set: !!priceSet, source: 'dom_fallback' };
+  if (result?.error) {
+    return { success: false, error: result.error, source: 'pricealerts_api' };
+  }
+  if (result?.data?.s !== 'ok' || !result.data.r?.alert_id) {
+    return { success: false, error: result?.data?.errmsg || 'Unknown API error', response: result?.data, source: 'pricealerts_api' };
+  }
+
+  const a = result.data.r;
+  return {
+    success: true,
+    source: 'pricealerts_api',
+    alert_id: a.alert_id,
+    symbol: ctx.symbol,
+    price,
+    condition: ctype,
+    message: a.message,
+    active: a.active,
+    expiration: a.expiration,
+  };
 }
 
 export async function list() {


### PR DESCRIPTION
## Summary
- `tv alert create` was always returning `{ success: false, price_set: false, source: 'dom_fallback' }`. The DOM walk in `core/alerts.js` looked for a `Create Alert` button that no longer exists in TradingView's DOM (they now use lowercase `Create alert`), and even when the dialog opened, the React-aware `nativeSetter` write to the price input didn't update TradingView's internal state — so clicking Create submitted the auto-populated price, not the requested one.
- Replaced the DOM walk with a direct POST to the same REST endpoint TradingView's UI uses, discovered via CDP Network capture: `POST https://pricealerts.tradingview.com/create_alert?log_username=<user>` with `Content-Type: text/plain;charset=UTF-8`.

## Why `text/plain`
The endpoint rejects `application/json` at the CORS preflight stage. That's why a naive direct `fetch()` from anywhere on `tradingview.com` fails with "Failed to fetch" — TradingView's UI itself sends the body as `text/plain` to skip preflight. The patched `create()` does the same.

## Behavior
- Symbol and username are resolved at call time from `window.TradingViewApi._activeChartWidgetWV.value().symbol()` and `window.user.username`, so the alert is created against whatever symbol the chart is currently showing.
- Default 30-day expiration; `mobile_push: true`, `popup: true`, email/SMS off (matches TV's UI defaults).
- Default message generated from symbol/condition/price when none is provided.
- Conditions supported: `crossing` (default), `greater_than`, `less_than`.
- Returns `{ success, alert_id, symbol, price, condition, message, active, expiration, source: 'pricealerts_api' }` on success; `{ success: false, error, source: 'pricealerts_api' }` on failure.

## Test plan
- [x] `node src/cli/index.js alert create -p 999.99 -c crossing -m "test"` returns `{ success: true, alert_id: <n>, ... }` and the new alert appears in `alert list`.
- [x] Verified an AAPL crossing alert at 270.89 round-trips correctly: created via patched CLI, listed via `alert list`, deleted via existing delete flow.
- [x] `alert list` (unchanged) still returns the existing 200+ alerts.
- [ ] Reviewer to confirm the resolved chart symbol matches expectations on their setup (BATS:AAPL vs NASDAQ:AAPL etc. — TradingView accepts either).