### PR TITLE
Add coordinate-based hover support to ui_hover tool

### DIFF
--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -191,6 +191,17 @@ export async function typeText({ text }) {
 }
 
 export async function hover({ by, value }) {
+  // Support raw coordinate hover: by='coords', value='x,y'
+  if (by === 'coords') {
+    const parts = value.split(',');
+    const x = parseFloat(parts[0]);
+    const y = parseFloat(parts[1]);
+    if (isNaN(x) || isNaN(y)) throw new Error('Invalid coords format. Use "x,y" e.g. "256,393"');
+    const c = await getClient();
+    await c.Input.dispatchMouseEvent({ type: 'mouseMoved', x, y });
+    return { success: true, hovered: { by: 'coords', value, tag: 'coords', x, y } };
+  }
+
   const coords = await evaluate(`
     (function() {
       var by = ${JSON.stringify(by)};

--- a/src/tools/ui.js
+++ b/src/tools/ui.js
@@ -51,9 +51,9 @@ export function registerUiTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('ui_hover', 'Hover over a UI element by aria-label, data-name, or text content', {
-    by: z.enum(['aria-label', 'data-name', 'text', 'class-contains']).describe('Selector strategy'),
-    value: z.string().describe('Value to match'),
+  server.tool('ui_hover', 'Hover over a UI element by aria-label, data-name, text content, or raw coordinates', {
+    by: z.enum(['aria-label', 'data-name', 'text', 'class-contains', 'coords']).describe('Selector strategy. Use "coords" with value="x,y" for raw coordinate hover (e.g. to trigger hover state on chart pane legends)'),
+    value: z.string().describe('Value to match, or "x,y" when by=coords'),
   }, async ({ by, value }) => {
     try { return jsonResult(await core.hover({ by, value })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }


### PR DESCRIPTION
## Summary

- Adds `by='coords'` mode to the `ui_hover` tool, enabling hover events at raw x,y screen coordinates
- Sends a CDP `Input.dispatchMouseEvent` (type `mouseMoved`) directly to the specified pixel position — no DOM selector required
- Updates the `ui_hover` Zod schema in `src/tools/ui.js` to include `'coords'` in the `by` enum

## Motivation

TradingView renders indicator legend buttons (Settings ⚙️, Hide, Remove, More) as DOM overlays that only appear when the cursor physically hovers over the legend area. Selector-based hover (`aria-label`, `data-name`, etc.) targets elements by DOM identity but cannot reliably trigger TradingView's internal hover state at a specific vertical position on the pane.

The new `coords` strategy solves this by dispatching a raw `mouseMoved` CDP event at an exact `(x, y)` coordinate, which TradingView treats as a real mouse move and responds to by rendering the appropriate legend buttons.

## Files Changed

- **`src/core/ui.js`** — Added early-return branch in `hover()` for `by === 'coords'`; parses `value` as `"x,y"`, validates, and calls `c.Input.dispatchMouseEvent({ type: 'mouseMoved', x, y })`
- **`src/tools/ui.js`** — Added `'coords'` to the `z.enum` for the `by` parameter of `ui_hover`; updated description to document the new strategy

## Usage

```
ui_hover(by="coords", value="256,393")
```

This moves the mouse to pixel (256, 393) on the TradingView window, triggering any hover-dependent UI elements at that position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)