### PR TITLE
Add VWAP + Volume Profile intraday trading framework

### DIFF
--- a/intraday-analyzer.js
+++ b/intraday-analyzer.js
@@ -106,17 +106,19 @@ function analyzeVWAP(data) {
       if (vwapEntry) {
         vwap = parseNum(vwapEntry[1]);
       }
-      const bandEntries = entries.filter(([k]) => !k.toLowerCase().includes("vwap"));
-      const bandNums = bandEntries.map(([, v]) => parseNum(v)).filter((n) => !isNaN(n));
-      if (bandNums.length >= 2) {
-        upperBand1 = Math.max(bandNums[0], bandNums[1]);
-        lowerBand1 = Math.min(bandNums[0], bandNums[1]);
+      for (const [k, v] of entries) {
+        const kl = k.toLowerCase();
+        if (kl.includes("vwap")) continue;
+        const n = parseNum(v);
+        if (isNaN(n)) continue;
+        if ((kl.includes("inner") || kl.includes("1")) && kl.includes("upper")) upperBand1 = n;
+        else if ((kl.includes("inner") || kl.includes("1")) && kl.includes("lower")) lowerBand1 = n;
+        else if ((kl.includes("outer") || kl.includes("2")) && kl.includes("upper")) upperBand2 = n;
+        else if ((kl.includes("outer") || kl.includes("2")) && kl.includes("lower")) lowerBand2 = n;
+        else if (kl.includes("upper") && !upperBand1) upperBand1 = n;
+        else if (kl.includes("lower") && !lowerBand1) lowerBand1 = n;
       }
-      if (bandNums.length >= 4) {
-        upperBand2 = Math.max(...bandNums);
-        lowerBand2 = Math.min(...bandNums);
-      }
-      if (!vwap && bandNums.length === 0) {
+      if (!vwap && !upperBand1 && !lowerBand1) {
         const allNums = entries.map(([, v]) => parseNum(v)).filter((n) => !isNaN(n));
         if (allNums.length >= 1) vwap = allNums[0];
       }
@@ -140,9 +142,14 @@ function analyzeVWAP(data) {
 }
 
 function analyzeVolumeProfile(data) {
-  const { pineLines, pineLabels, pineTables } = data;
+  const { pineLines, pineLabels, pineTables, studyValues } = data;
   const levels = { poc: null, vah: null, val: null, hvns: [], lvns: [] };
 
+  function parseNum(s) {
+    return Number(String(s).replace(/,/g, "").replace(/[^\d.\-]/g, ""));
+  }
+
+  // Check pine labels for POC/VAH/VAL text
   const allLabels = [];
   if (pineLabels?.studies) {
     for (const study of Object.values(pineLabels.studies)) {
@@ -156,9 +163,23 @@ function analyzeVolumeProfile(data) {
     const price = label.price ?? label.y;
     if (txt.includes("POC")) levels.poc = price;
     else if (txt.includes("VAH")) levels.vah = price;
-    else if (txt.includes("VAL")) levels.val = price;
+    else if (txt.includes("VAL") && !txt.includes("VALUE")) levels.val = price;
     else if (txt.includes("HVN")) levels.hvns.push(price);
     else if (txt.includes("LVN")) levels.lvns.push(price);
+  }
+
+  // Fallback: check study values for POC/VAH/VAL keys
+  if (!levels.poc || !levels.vah || !levels.val) {
+    for (const study of (studyValues?.studies || [])) {
+      for (const [k, v] of Object.entries(study.values || {})) {
+        const kl = k.toLowerCase();
+        const n = parseNum(v);
+        if (isNaN(n)) continue;
+        if (!levels.poc && kl.includes("poc")) levels.poc = n;
+        else if (!levels.vah && kl.includes("vah")) levels.vah = n;
+        else if (!levels.val && kl.includes("val") && !kl.includes("value")) levels.val = n;
+      }
+    }
   }
 
   const allLines = [];
@@ -386,6 +407,8 @@ async function run() {
   if (vwapResult.vwap) {
     console.log(`  VWAP:     ${vwapResult.vwap}`);
     console.log(`  Position: ${vwapResult.position} (${vwapResult.distPct}% from VWAP)`);
+    if (vwapResult.upperBand1) console.log(`  ±1σ:      ${vwapResult.upperBand1} / ${vwapResult.lowerBand1}`);
+    if (vwapResult.upperBand2) console.log(`  ±2σ:      ${vwapResult.upperBand2} / ${vwapResult.lowerBand2}`);
   } else {
     console.log("  VWAP:     ⚠ Not detected — add VWAP indicator to chart");
   }

--- a/intraday-analyzer.js
+++ b/intraday-analyzer.js
@@ -1,0 +1,403 @@
+#!/usr/bin/env node
+/**
+ * VWAP + Volume Profile Intraday Analyzer
+ *
+ * Connects to TradingView via MCP tools (CDP port 9222) and produces
+ * a structured trade plan based on rules.json.
+ *
+ * Usage:  node intraday-analyzer.js
+ *         node intraday-analyzer.js --symbol NIFTY1!
+ *         node intraday-analyzer.js --timeframe 5
+ *
+ * This script is meant to be run alongside Claude Code + TradingView MCP.
+ * It reads chart data through the MCP server's tool handlers.
+ */
+
+import { readFileSync } from "fs";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const rules = JSON.parse(
+  readFileSync(new URL("rules.json", import.meta.url), "utf8")
+);
+
+// ── CLI args ────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+function flag(name) {
+  const i = args.indexOf(`--${name}`);
+  return i !== -1 ? args[i + 1] : null;
+}
+const SYMBOL = flag("symbol") || rules.watchlist[0];
+const TIMEFRAME = flag("timeframe") || rules.default_timeframe;
+
+// ── MCP client ──────────────────────────────────────────────────
+let client;
+
+async function connect() {
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: ["src/server.js"],
+  });
+  client = new Client({ name: "intraday-analyzer", version: "1.0.0" });
+  await client.connect(transport);
+}
+
+async function call(tool, params = {}) {
+  const result = await client.callTool({ name: tool, arguments: params });
+  const text = result.content?.find((c) => c.type === "text")?.text;
+  return text ? JSON.parse(text) : result;
+}
+
+// ── Data collection ─────────────────────────────────────────────
+async function gatherData() {
+  const [quote, state] = await Promise.all([
+    call("quote_get"),
+    call("chart_get_state"),
+  ]);
+
+  const [studyValues, ohlcv] = await Promise.all([
+    call("data_get_study_values"),
+    call("data_get_ohlcv", { count: 50, summary: true }),
+  ]);
+
+  let pineLines = null;
+  let pineLabels = null;
+  let pineTables = null;
+  try {
+    [pineLines, pineLabels, pineTables] = await Promise.all([
+      call("data_get_pine_lines"),
+      call("data_get_pine_labels"),
+      call("data_get_pine_tables"),
+    ]);
+  } catch {
+    // Pine graphics may not be available if no custom indicators
+  }
+
+  return { quote, state, studyValues, ohlcv, pineLines, pineLabels, pineTables };
+}
+
+// ── Analysis engine ─────────────────────────────────────────────
+function analyzeVWAP(data) {
+  const { quote, studyValues } = data;
+  const price = quote?.last ?? quote?.lp;
+  const values = studyValues?.studies || studyValues?.values || {};
+
+  let vwap = null;
+  let upperBand1 = null;
+  let lowerBand1 = null;
+  let upperBand2 = null;
+  let lowerBand2 = null;
+
+  for (const [name, vals] of Object.entries(values)) {
+    const lower = name.toLowerCase();
+    if (lower.includes("vwap") || lower.includes("anchored")) {
+      const v = Array.isArray(vals) ? vals : Object.values(vals);
+      if (v.length >= 1) vwap = v[0];
+      if (v.length >= 3) {
+        upperBand1 = v[1];
+        lowerBand1 = v[2];
+      }
+      if (v.length >= 5) {
+        upperBand2 = v[3];
+        lowerBand2 = v[4];
+      }
+    }
+  }
+
+  if (!vwap || !price) {
+    return { position: "unknown", vwap: null, distance: null };
+  }
+
+  const distPct = ((price - vwap) / vwap) * 100;
+  let position;
+  if (upperBand2 && price >= upperBand2) position = "extended_above_2σ";
+  else if (upperBand1 && price >= upperBand1) position = "above_1σ";
+  else if (price > vwap) position = "above_vwap";
+  else if (lowerBand2 && price <= lowerBand2) position = "extended_below_2σ";
+  else if (lowerBand1 && price <= lowerBand1) position = "below_1σ";
+  else position = "below_vwap";
+
+  return { position, vwap, price, distPct: distPct.toFixed(2), upperBand1, lowerBand1, upperBand2, lowerBand2 };
+}
+
+function analyzeVolumeProfile(data) {
+  const { pineLines, pineLabels, pineTables } = data;
+  const levels = { poc: null, vah: null, val: null, hvns: [], lvns: [] };
+
+  const allLabels = [];
+  if (pineLabels?.studies) {
+    for (const study of Object.values(pineLabels.studies)) {
+      if (Array.isArray(study)) allLabels.push(...study);
+      else if (study.labels) allLabels.push(...study.labels);
+    }
+  }
+
+  for (const label of allLabels) {
+    const txt = (label.text || label.label || "").toUpperCase();
+    const price = label.price ?? label.y;
+    if (txt.includes("POC")) levels.poc = price;
+    else if (txt.includes("VAH")) levels.vah = price;
+    else if (txt.includes("VAL")) levels.val = price;
+    else if (txt.includes("HVN")) levels.hvns.push(price);
+    else if (txt.includes("LVN")) levels.lvns.push(price);
+  }
+
+  const allLines = [];
+  if (pineLines?.studies) {
+    for (const study of Object.values(pineLines.studies)) {
+      if (Array.isArray(study)) allLines.push(...study);
+      else if (study.lines) allLines.push(...study.lines);
+    }
+  }
+
+  if (!levels.poc && allLines.length > 0) {
+    const sorted = allLines
+      .map((l) => l.price ?? l.y)
+      .filter(Boolean)
+      .sort((a, b) => a - b);
+    if (sorted.length >= 3) {
+      const mid = Math.floor(sorted.length / 2);
+      levels.poc = sorted[mid];
+      levels.vah = sorted[Math.floor(sorted.length * 0.7)];
+      levels.val = sorted[Math.floor(sorted.length * 0.3)];
+    }
+  }
+
+  return levels;
+}
+
+function analyzePriceAction(data) {
+  const { ohlcv } = data;
+  const bars = ohlcv?.bars || ohlcv?.data || [];
+  if (bars.length < 5) return { trend: "insufficient_data", patterns: [] };
+
+  const recent = bars.slice(-10);
+  const highs = recent.map((b) => b.high || b.h);
+  const lows = recent.map((b) => b.low || b.l);
+  const closes = recent.map((b) => b.close || b.c);
+
+  let higherHighs = 0;
+  let lowerLows = 0;
+  for (let i = 1; i < highs.length; i++) {
+    if (highs[i] > highs[i - 1]) higherHighs++;
+    if (lows[i] < lows[i - 1]) lowerLows++;
+  }
+
+  let trend;
+  if (higherHighs >= 3 && lowerLows <= 1) trend = "uptrend";
+  else if (lowerLows >= 3 && higherHighs <= 1) trend = "downtrend";
+  else trend = "ranging";
+
+  const patterns = [];
+  const last = bars[bars.length - 1];
+  const prev = bars[bars.length - 2];
+  if (last && prev) {
+    const lastO = last.open || last.o;
+    const lastC = last.close || last.c;
+    const lastH = last.high || last.h;
+    const lastL = last.low || last.l;
+    const prevO = prev.open || prev.o;
+    const prevC = prev.close || prev.c;
+
+    const body = Math.abs(lastC - lastO);
+    const range = lastH - lastL;
+
+    if (range > 0 && body / range < 0.3) {
+      const upperWick = lastH - Math.max(lastO, lastC);
+      const lowerWick = Math.min(lastO, lastC) - lastL;
+      if (lowerWick > body * 2) patterns.push("hammer");
+      if (upperWick > body * 2) patterns.push("shooting_star");
+    }
+
+    if (lastC > lastO && prevC < prevO && lastC > prevO && lastO < prevC)
+      patterns.push("bullish_engulfing");
+    if (lastC < lastO && prevC > prevO && lastC < prevO && lastO > prevC)
+      patterns.push("bearish_engulfing");
+
+    if (
+      Math.max(lastO, lastC) <= Math.max(prevO, prevC) &&
+      Math.min(lastO, lastC) >= Math.min(prevO, prevC)
+    )
+      patterns.push("inside_bar");
+  }
+
+  return { trend, patterns, higherHighs, lowerLows };
+}
+
+function determineBias(vwapAnalysis, vpLevels, priceAction) {
+  let bullishScore = 0;
+  let bearishScore = 0;
+
+  if (["above_vwap", "above_1σ"].includes(vwapAnalysis.position)) bullishScore += 2;
+  if (["below_vwap", "below_1σ"].includes(vwapAnalysis.position)) bearishScore += 2;
+  if (vwapAnalysis.position === "extended_above_2σ") bearishScore += 1; // overextended
+  if (vwapAnalysis.position === "extended_below_2σ") bullishScore += 1; // overextended
+
+  if (vpLevels.poc && vwapAnalysis.price) {
+    if (vwapAnalysis.price > vpLevels.poc) bullishScore += 1;
+    else bearishScore += 1;
+  }
+
+  if (priceAction.trend === "uptrend") bullishScore += 2;
+  if (priceAction.trend === "downtrend") bearishScore += 2;
+
+  const diff = bullishScore - bearishScore;
+  if (diff >= 3) return "strongly_bullish";
+  if (diff >= 1) return "bullish";
+  if (diff <= -3) return "strongly_bearish";
+  if (diff <= -1) return "bearish";
+  return "neutral";
+}
+
+function findSetups(bias, vwapAnalysis, vpLevels, priceAction) {
+  const setups = [];
+  const price = vwapAnalysis.price;
+  if (!price) return setups;
+
+  // Trend continuation
+  if (
+    (bias.includes("bullish") && vwapAnalysis.position === "above_vwap") ||
+    (bias.includes("bullish") && priceAction.patterns.includes("hammer"))
+  ) {
+    setups.push({
+      type: "trend_continuation",
+      direction: "long",
+      trigger: `Pullback to VWAP (${vwapAnalysis.vwap?.toFixed(2)}) with bullish PA`,
+      target: vpLevels.vah
+        ? `VAH ${vpLevels.vah.toFixed(2)}`
+        : `VWAP +1σ ${vwapAnalysis.upperBand1?.toFixed(2) || "N/A"}`,
+      stop: vpLevels.val
+        ? `Below VAL ${vpLevels.val.toFixed(2)}`
+        : `Below VWAP ${vwapAnalysis.vwap?.toFixed(2)}`,
+    });
+  }
+
+  if (
+    (bias.includes("bearish") && vwapAnalysis.position === "below_vwap") ||
+    (bias.includes("bearish") && priceAction.patterns.includes("shooting_star"))
+  ) {
+    setups.push({
+      type: "trend_continuation",
+      direction: "short",
+      trigger: `Rally to VWAP (${vwapAnalysis.vwap?.toFixed(2)}) with bearish PA`,
+      target: vpLevels.val
+        ? `VAL ${vpLevels.val.toFixed(2)}`
+        : `VWAP -1σ ${vwapAnalysis.lowerBand1?.toFixed(2) || "N/A"}`,
+      stop: vpLevels.vah
+        ? `Above VAH ${vpLevels.vah.toFixed(2)}`
+        : `Above VWAP ${vwapAnalysis.vwap?.toFixed(2)}`,
+    });
+  }
+
+  // Mean reversion
+  if (vwapAnalysis.position === "extended_below_2σ" && !bias.includes("strongly_bearish")) {
+    setups.push({
+      type: "mean_reversion",
+      direction: "long",
+      trigger: `Price at VWAP -2σ — look for bullish reversal candle on 5m`,
+      target: `VWAP ${vwapAnalysis.vwap?.toFixed(2)}`,
+      stop: `Below swing low`,
+    });
+  }
+
+  if (vwapAnalysis.position === "extended_above_2σ" && !bias.includes("strongly_bullish")) {
+    setups.push({
+      type: "mean_reversion",
+      direction: "short",
+      trigger: `Price at VWAP +2σ — look for bearish reversal candle on 5m`,
+      target: `VWAP ${vwapAnalysis.vwap?.toFixed(2)}`,
+      stop: `Above swing high`,
+    });
+  }
+
+  // Breakout
+  if (vpLevels.vah && price > vpLevels.vah * 0.998 && price < vpLevels.vah * 1.005) {
+    setups.push({
+      type: "breakout",
+      direction: "long",
+      trigger: `Price near VAH (${vpLevels.vah.toFixed(2)}) — watch for breakout + retest`,
+      target: `Next resistance / VWAP +2σ`,
+      stop: `Below VAH ${vpLevels.vah.toFixed(2)}`,
+    });
+  }
+
+  if (vpLevels.val && price < vpLevels.val * 1.002 && price > vpLevels.val * 0.995) {
+    setups.push({
+      type: "breakout",
+      direction: "short",
+      trigger: `Price near VAL (${vpLevels.val.toFixed(2)}) — watch for breakdown + retest`,
+      target: `Next support / VWAP -2σ`,
+      stop: `Above VAL ${vpLevels.val.toFixed(2)}`,
+    });
+  }
+
+  return setups;
+}
+
+// ── Main ────────────────────────────────────────────────────────
+async function run() {
+  console.log("═══════════════════════════════════════════════════════");
+  console.log("  VWAP + Volume Profile Intraday Analyzer");
+  console.log(`  Symbol: ${SYMBOL}  |  Timeframe: ${TIMEFRAME}m`);
+  console.log(`  ${new Date().toLocaleString()}`);
+  console.log("═══════════════════════════════════════════════════════\n");
+
+  await connect();
+
+  console.log("Gathering chart data...\n");
+  const data = await gatherData();
+
+  const vwapResult = analyzeVWAP(data);
+  const vpLevels = analyzeVolumeProfile(data);
+  const paResult = analyzePriceAction(data);
+  const bias = determineBias(vwapResult, vpLevels, paResult);
+  const setups = findSetups(bias, vwapResult, vpLevels, paResult);
+
+  // Report
+  console.log("── VWAP Analysis ──────────────────────────────────────");
+  console.log(`  Price:    ${vwapResult.price}`);
+  console.log(`  VWAP:     ${vwapResult.vwap}`);
+  console.log(`  Position: ${vwapResult.position} (${vwapResult.distPct}% from VWAP)`);
+  console.log();
+
+  console.log("── Volume Profile Levels ──────────────────────────────");
+  console.log(`  POC: ${vpLevels.poc ?? "not detected"}`);
+  console.log(`  VAH: ${vpLevels.vah ?? "not detected"}`);
+  console.log(`  VAL: ${vpLevels.val ?? "not detected"}`);
+  if (vpLevels.hvns.length) console.log(`  HVNs: ${vpLevels.hvns.join(", ")}`);
+  if (vpLevels.lvns.length) console.log(`  LVNs: ${vpLevels.lvns.join(", ")}`);
+  console.log();
+
+  console.log("── Price Action ───────────────────────────────────────");
+  console.log(`  Trend: ${paResult.trend}`);
+  console.log(`  Patterns: ${paResult.patterns.length ? paResult.patterns.join(", ") : "none"}`);
+  console.log();
+
+  console.log("── SESSION BIAS ───────────────────────────────────────");
+  console.log(`  >>> ${bias.toUpperCase().replace(/_/g, " ")} <<<`);
+  console.log();
+
+  if (setups.length === 0) {
+    console.log("── No actionable setups right now ──────────────────────");
+    console.log("  Wait for price to reach a key level with confirmation.");
+  } else {
+    console.log(`── ${setups.length} Setup(s) Identified ──────────────────────────`);
+    for (const s of setups) {
+      console.log(`\n  [${s.type.toUpperCase()}] ${s.direction.toUpperCase()}`);
+      console.log(`  Trigger: ${s.trigger}`);
+      console.log(`  Target:  ${s.target}`);
+      console.log(`  Stop:    ${s.stop}`);
+    }
+  }
+
+  console.log("\n═══════════════════════════════════════════════════════");
+  console.log("  Remember: R:R min 1.5:1 | Risk 1% | Max 3 losses = done");
+  console.log("═══════════════════════════════════════════════════════\n");
+
+  await client.close();
+}
+
+run().catch((err) => {
+  console.error("Error:", err.message);
+  process.exit(1);
+});

--- a/intraday-analyzer.js
+++ b/intraday-analyzer.js
@@ -89,19 +89,36 @@ function analyzeVWAP(data) {
   let upperBand2 = null;
   let lowerBand2 = null;
 
+  function parseNum(s) {
+    return Number(String(s).replace(/,/g, "").replace(/[^\d.\-]/g, ""));
+  }
+
   for (const study of studies) {
-    const lower = (study.name || "").toLowerCase();
-    if (lower.includes("vwap") || lower.includes("anchored")) {
-      const vals = study.values || {};
-      const nums = Object.values(vals).map(Number).filter((n) => !isNaN(n));
-      if (nums.length >= 1) vwap = nums[0];
-      if (nums.length >= 3) {
-        upperBand1 = nums[1];
-        lowerBand1 = nums[2];
+    const nameLower = (study.name || "").toLowerCase();
+    const vals = study.values || {};
+    const keysLower = Object.keys(vals).map((k) => k.toLowerCase());
+    const nameMatch = nameLower.includes("vwap") || nameLower.includes("anchored");
+    const keyMatch = keysLower.some((k) => k.includes("vwap"));
+
+    if (nameMatch || keyMatch) {
+      const entries = Object.entries(vals);
+      const vwapEntry = entries.find(([k]) => k.toLowerCase().includes("vwap"));
+      if (vwapEntry) {
+        vwap = parseNum(vwapEntry[1]);
       }
-      if (nums.length >= 5) {
-        upperBand2 = nums[3];
-        lowerBand2 = nums[4];
+      const bandEntries = entries.filter(([k]) => !k.toLowerCase().includes("vwap"));
+      const bandNums = bandEntries.map(([, v]) => parseNum(v)).filter((n) => !isNaN(n));
+      if (bandNums.length >= 2) {
+        upperBand1 = Math.max(bandNums[0], bandNums[1]);
+        lowerBand1 = Math.min(bandNums[0], bandNums[1]);
+      }
+      if (bandNums.length >= 4) {
+        upperBand2 = Math.max(...bandNums);
+        lowerBand2 = Math.min(...bandNums);
+      }
+      if (!vwap && bandNums.length === 0) {
+        const allNums = entries.map(([, v]) => parseNum(v)).filter((n) => !isNaN(n));
+        if (allNums.length >= 1) vwap = allNums[0];
       }
     }
   }

--- a/intraday-analyzer.js
+++ b/intraday-analyzer.js
@@ -144,12 +144,34 @@ function analyzeVWAP(data) {
 function analyzeVolumeProfile(data) {
   const { pineLines, pineLabels, pineTables, studyValues } = data;
   const levels = { poc: null, vah: null, val: null, hvns: [], lvns: [] };
+  const context = { dayType: null, trend: null, priceZone: null, ibPosition: null, yPOC: null };
 
   function parseNum(s) {
     return Number(String(s).replace(/,/g, "").replace(/[^\d.\-]/g, ""));
   }
 
-  // Check pine labels for POC/VAH/VAL text
+  // Primary: parse pine tables (WillyAlgo format: "POC | 80730.0")
+  if (pineTables?.studies) {
+    for (const study of Object.values(pineTables.studies)) {
+      const tables = study.tables || (Array.isArray(study) ? study : []);
+      for (const table of tables) {
+        for (const row of (table.rows || [])) {
+          const [key, val] = String(row).split("|").map((s) => s.trim());
+          if (!key || !val) continue;
+          const kl = key.toLowerCase();
+          if (kl === "poc") levels.poc = parseNum(val);
+          else if (kl === "vah") levels.vah = parseNum(val);
+          else if (kl === "val") levels.val = parseNum(val);
+          else if (kl === "day type") context.dayType = val;
+          else if (kl === "trend") context.trend = val;
+          else if (kl === "price zone") context.priceZone = val;
+          else if (kl === "ib position") context.ibPosition = val;
+        }
+      }
+    }
+  }
+
+  // Fallback: check pine labels for POC/VAH/VAL text
   const allLabels = [];
   if (pineLabels?.studies) {
     for (const study of Object.values(pineLabels.studies)) {
@@ -161,11 +183,12 @@ function analyzeVolumeProfile(data) {
   for (const label of allLabels) {
     const txt = (label.text || label.label || "").toUpperCase();
     const price = label.price ?? label.y;
-    if (txt.includes("POC")) levels.poc = price;
-    else if (txt.includes("VAH")) levels.vah = price;
-    else if (txt.includes("VAL") && !txt.includes("VALUE")) levels.val = price;
+    if (!levels.poc && txt.includes("POC") && !txt.includes("YPOC")) levels.poc = price;
+    else if (!levels.vah && txt.includes("VAH")) levels.vah = price;
+    else if (!levels.val && txt.includes("VAL") && !txt.includes("VALUE")) levels.val = price;
     else if (txt.includes("HVN")) levels.hvns.push(price);
     else if (txt.includes("LVN")) levels.lvns.push(price);
+    else if (txt === "YPOC" || txt.includes("YPOC")) context.yPOC = price;
   }
 
   // Fallback: check study values for POC/VAH/VAL keys
@@ -182,28 +205,7 @@ function analyzeVolumeProfile(data) {
     }
   }
 
-  const allLines = [];
-  if (pineLines?.studies) {
-    for (const study of Object.values(pineLines.studies)) {
-      if (Array.isArray(study)) allLines.push(...study);
-      else if (study.lines) allLines.push(...study.lines);
-    }
-  }
-
-  if (!levels.poc && allLines.length > 0) {
-    const sorted = allLines
-      .map((l) => l.price ?? l.y)
-      .filter(Boolean)
-      .sort((a, b) => a - b);
-    if (sorted.length >= 3) {
-      const mid = Math.floor(sorted.length / 2);
-      levels.poc = sorted[mid];
-      levels.vah = sorted[Math.floor(sorted.length * 0.7)];
-      levels.val = sorted[Math.floor(sorted.length * 0.3)];
-    }
-  }
-
-  return levels;
+  return { ...levels, context };
 }
 
 function analyzePriceAction(data) {
@@ -420,6 +422,16 @@ async function run() {
   console.log(`  VAL: ${vpLevels.val ?? "not detected"}`);
   if (vpLevels.hvns.length) console.log(`  HVNs: ${vpLevels.hvns.join(", ")}`);
   if (vpLevels.lvns.length) console.log(`  LVNs: ${vpLevels.lvns.join(", ")}`);
+  if (vpLevels.context?.yPOC) console.log(`  yPOC: ${vpLevels.context.yPOC}`);
+  const ctx = vpLevels.context;
+  if (ctx?.dayType || ctx?.trend || ctx?.priceZone) {
+    const parts = [];
+    if (ctx.dayType) parts.push(`Day: ${ctx.dayType}`);
+    if (ctx.trend) parts.push(`Trend: ${ctx.trend}`);
+    if (ctx.priceZone) parts.push(ctx.priceZone);
+    if (ctx.ibPosition) parts.push(ctx.ibPosition);
+    console.log(`  WillyAlgo: ${parts.join(" | ")}`);
+  }
   console.log();
 
   console.log("── Price Action ───────────────────────────────────────");

--- a/intraday-analyzer.js
+++ b/intraday-analyzer.js
@@ -55,9 +55,10 @@ async function gatherData() {
     call("chart_get_state"),
   ]);
 
-  const [studyValues, ohlcv] = await Promise.all([
+  const [studyValues, ohlcvSummary, ohlcvBars] = await Promise.all([
     call("data_get_study_values"),
     call("data_get_ohlcv", { count: 50, summary: true }),
+    call("data_get_ohlcv", { count: 20 }),
   ]);
 
   let pineLines = null;
@@ -73,14 +74,14 @@ async function gatherData() {
     // Pine graphics may not be available if no custom indicators
   }
 
-  return { quote, state, studyValues, ohlcv, pineLines, pineLabels, pineTables };
+  return { quote, state, studyValues, ohlcvSummary, ohlcvBars, pineLines, pineLabels, pineTables };
 }
 
 // ── Analysis engine ─────────────────────────────────────────────
 function analyzeVWAP(data) {
   const { quote, studyValues } = data;
-  const price = quote?.last ?? quote?.lp;
-  const values = studyValues?.studies || studyValues?.values || {};
+  const price = quote?.last ?? quote?.close;
+  const studies = studyValues?.studies || [];
 
   let vwap = null;
   let upperBand1 = null;
@@ -88,24 +89,25 @@ function analyzeVWAP(data) {
   let upperBand2 = null;
   let lowerBand2 = null;
 
-  for (const [name, vals] of Object.entries(values)) {
-    const lower = name.toLowerCase();
+  for (const study of studies) {
+    const lower = (study.name || "").toLowerCase();
     if (lower.includes("vwap") || lower.includes("anchored")) {
-      const v = Array.isArray(vals) ? vals : Object.values(vals);
-      if (v.length >= 1) vwap = v[0];
-      if (v.length >= 3) {
-        upperBand1 = v[1];
-        lowerBand1 = v[2];
+      const vals = study.values || {};
+      const nums = Object.values(vals).map(Number).filter((n) => !isNaN(n));
+      if (nums.length >= 1) vwap = nums[0];
+      if (nums.length >= 3) {
+        upperBand1 = nums[1];
+        lowerBand1 = nums[2];
       }
-      if (v.length >= 5) {
-        upperBand2 = v[3];
-        lowerBand2 = v[4];
+      if (nums.length >= 5) {
+        upperBand2 = nums[3];
+        lowerBand2 = nums[4];
       }
     }
   }
 
   if (!vwap || !price) {
-    return { position: "unknown", vwap: null, distance: null };
+    return { position: "unknown", vwap: null, price, distPct: null };
   }
 
   const distPct = ((price - vwap) / vwap) * 100;
@@ -167,14 +169,14 @@ function analyzeVolumeProfile(data) {
 }
 
 function analyzePriceAction(data) {
-  const { ohlcv } = data;
-  const bars = ohlcv?.bars || ohlcv?.data || [];
+  const { ohlcvBars } = data;
+  const bars = ohlcvBars?.bars || [];
   if (bars.length < 5) return { trend: "insufficient_data", patterns: [] };
 
   const recent = bars.slice(-10);
-  const highs = recent.map((b) => b.high || b.h);
-  const lows = recent.map((b) => b.low || b.l);
-  const closes = recent.map((b) => b.close || b.c);
+  const highs = recent.map((b) => b.high);
+  const lows = recent.map((b) => b.low);
+  const closes = recent.map((b) => b.close);
 
   let higherHighs = 0;
   let lowerLows = 0;
@@ -192,12 +194,12 @@ function analyzePriceAction(data) {
   const last = bars[bars.length - 1];
   const prev = bars[bars.length - 2];
   if (last && prev) {
-    const lastO = last.open || last.o;
-    const lastC = last.close || last.c;
-    const lastH = last.high || last.h;
-    const lastL = last.low || last.l;
-    const prevO = prev.open || prev.o;
-    const prevC = prev.close || prev.c;
+    const lastO = last.open;
+    const lastC = last.close;
+    const lastH = last.high;
+    const lastL = last.low;
+    const prevO = prev.open;
+    const prevC = prev.close;
 
     const body = Math.abs(lastC - lastO);
     const range = lastH - lastL;
@@ -354,10 +356,22 @@ async function run() {
   const setups = findSetups(bias, vwapResult, vpLevels, paResult);
 
   // Report
+  const s = data.ohlcvSummary;
+  console.log("── Price Summary ──────────────────────────────────────");
+  console.log(`  Open:    ${s?.open ?? "N/A"}    High: ${s?.high ?? "N/A"}`);
+  console.log(`  Low:     ${s?.low ?? "N/A"}    Close: ${s?.close ?? "N/A"}`);
+  console.log(`  Range:   ${s?.range ?? "N/A"}    Change: ${s?.change_pct ?? "N/A"}`);
+  console.log(`  Avg Vol: ${s?.avg_volume ?? "N/A"}`);
+  console.log();
+
   console.log("── VWAP Analysis ──────────────────────────────────────");
-  console.log(`  Price:    ${vwapResult.price}`);
-  console.log(`  VWAP:     ${vwapResult.vwap}`);
-  console.log(`  Position: ${vwapResult.position} (${vwapResult.distPct}% from VWAP)`);
+  console.log(`  Price:    ${vwapResult.price ?? "N/A"}`);
+  if (vwapResult.vwap) {
+    console.log(`  VWAP:     ${vwapResult.vwap}`);
+    console.log(`  Position: ${vwapResult.position} (${vwapResult.distPct}% from VWAP)`);
+  } else {
+    console.log("  VWAP:     ⚠ Not detected — add VWAP indicator to chart");
+  }
   console.log();
 
   console.log("── Volume Profile Levels ──────────────────────────────");

--- a/rules.json
+++ b/rules.json
@@ -1,65 +1,141 @@
 {
   "watchlist": ["BTCUSDT"],
-  "default_timeframe": "1",
+  "default_timeframe": "15",
 
   "strategy": {
-    "name": "10-Second Momentum Scalper",
+    "name": "VWAP + Volume Profile Intraday",
+    "style": "Intraday — hold minutes to hours, flat by session close",
     "sources": [
-      "Price momentum — buy if last close > previous close (green candle)",
-      "RSI filter — only trade when RSI is not at an extreme (30–70 range)"
+      "VWAP — dynamic mean-reversion anchor and trend filter",
+      "Volume Profile (session/visible range) — identify POC, VAH, VAL for S/R",
+      "Price Action — candle patterns, structure breaks, and failed auctions at key levels"
     ],
     "primary_timeframes": [
-      "1-minute (signal source)",
-      "10-second execution loop"
+      "15-minute (primary signal and trade management)",
+      "5-minute (precision entry timing)",
+      "1-hour (context and bias — higher timeframe trend)"
     ]
   },
 
   "indicators": {
-    "rsi_14": "Momentum filter. Only trade when RSI is between 30–70 (avoid extremes).",
-    "price_momentum": "Compare last close vs previous close. Up = long signal. Down = short signal."
+    "vwap": "Anchored to session open. Price above VWAP = bullish intraday bias. Below = bearish. Bands (1σ, 2σ) mark overextension zones.",
+    "volume_profile": "Session or visible-range VP. POC = fair value / magnet. VAH/VAL = value area boundaries. HVN = congestion / support. LVN = fast-move zones / rejection.",
+    "price_action": "Higher highs/lows for uptrend, lower highs/lows for downtrend. Key patterns: engulfing, pin bars, inside bars at VWAP or VP levels."
   },
 
   "bias_criteria": {
     "bullish": [
-      "Last 1-min candle closed higher than the one before it",
-      "RSI is between 30 and 70"
+      "Price trading above VWAP on 15m",
+      "Price accepted above POC or reclaimed VAH",
+      "1H structure shows higher lows",
+      "Volume increasing on up-moves"
     ],
     "bearish": [
-      "Last 1-min candle closed lower than the one before it",
-      "RSI is between 30 and 70"
+      "Price trading below VWAP on 15m",
+      "Price rejected from POC or lost VAL",
+      "1H structure shows lower highs",
+      "Volume increasing on down-moves"
     ],
     "neutral": [
-      "RSI is above 70 (overbought — skip)",
-      "RSI is below 30 (oversold — skip)",
-      "Candle close change is less than 0.05% (chop — skip)"
+      "Price chopping around VWAP with no directional commitment",
+      "Price inside value area with no breakout attempt",
+      "Low volume / lunchtime / pre-news consolidation"
     ]
   },
 
   "entry_rules": {
-    "long": [
-      "Last close > previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market buy immediately"
+    "trend_continuation": {
+      "long": [
+        "Bias is bullish (price above VWAP, above POC)",
+        "Price pulls back to VWAP or VAL and holds",
+        "Bullish price action at the level (engulfing, pin bar, or demand candle)",
+        "Enter on 5m confirmation candle close"
+      ],
+      "short": [
+        "Bias is bearish (price below VWAP, below POC)",
+        "Price rallies to VWAP or VAH and rejects",
+        "Bearish price action at the level (engulfing, shooting star, or supply candle)",
+        "Enter on 5m confirmation candle close"
+      ]
+    },
+    "mean_reversion": {
+      "long": [
+        "Price reaches VWAP -2σ band or below VAL",
+        "Volume profile shows HVN (prior support) nearby",
+        "Bullish reversal candle (hammer, engulfing) on 5m",
+        "Only take if 1H trend is not strongly bearish"
+      ],
+      "short": [
+        "Price reaches VWAP +2σ band or above VAH",
+        "Volume profile shows HVN (prior resistance) nearby",
+        "Bearish reversal candle (shooting star, engulfing) on 5m",
+        "Only take if 1H trend is not strongly bullish"
+      ]
+    },
+    "breakout": {
+      "long": [
+        "Price breaks above VAH with strong momentum candle",
+        "Volume on breakout bar is 1.5x+ average",
+        "Retest of VAH holds as support (failed auction below)",
+        "Enter on 5m close above VAH after retest"
+      ],
+      "short": [
+        "Price breaks below VAL with strong momentum candle",
+        "Volume on breakout bar is 1.5x+ average",
+        "Retest of VAL holds as resistance (failed auction above)",
+        "Enter on 5m close below VAL after retest"
+      ]
+    }
+  },
+
+  "exit_rules": {
+    "targets": [
+      "T1: Next VP level (POC, VAH, or VAL) — take 50% off",
+      "T2: VWAP band (±1σ or ±2σ depending on entry type) — take remaining",
+      "Breakout trades: trail stop below/above each new HVN as price discovers"
     ],
-    "short": [
-      "Last close < previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market sell immediately"
+    "stop_loss": [
+      "Below/above the entry-level structure (swing low/high on 5m)",
+      "Maximum 1 ATR(14) on the 15m chart",
+      "If price closes back inside value area after breakout, exit immediately"
+    ],
+    "time_stop": [
+      "If trade hasn't moved toward target within 30 minutes, tighten stop to breakeven",
+      "Close all positions before session end — no overnight holds"
     ]
   },
 
-  "exit_rules": [
-    "Exit automatically after 10 seconds (next loop tick closes previous position)",
-    "No manual exit management — pure time-based scalp"
-  ],
-
   "risk_rules": [
-    "Fixed trade size: 1% of portfolio per trade",
-    "Maximum trade size: $3.00",
-    "Maximum 6 trades per 60-second run",
-    "No stop loss — exit is time-based at next tick",
-    "For demo purposes only — minimum BitGet order size may apply"
+    "Risk 1% of account per trade",
+    "Maximum 3 concurrent positions",
+    "Maximum 3 losses in a row — stop trading for the session",
+    "No trading in first 5 minutes of session (let VWAP and VP establish)",
+    "No trading during major news events (wait 5 minutes after release)",
+    "R:R minimum 1.5:1 before entering"
   ],
 
-  "notes": "Demo strategy for YouTube video. Runs 6 trades over 60 seconds, one every 10 seconds. Signal is simple price momentum on 1-min candles with RSI sanity check."
+  "session_routine": {
+    "pre_market": [
+      "Mark prior session POC, VAH, VAL on chart",
+      "Note overnight high/low and any gaps",
+      "Identify key news events for the day"
+    ],
+    "first_15_minutes": [
+      "Observe — let opening range and VWAP establish",
+      "Identify initial balance high/low",
+      "Note where volume is building (developing POC)"
+    ],
+    "active_trading": [
+      "Trade setups from entry_rules above",
+      "Monitor developing VP for shifting POC",
+      "Track VWAP slope for trend strength"
+    ],
+    "last_30_minutes": [
+      "No new entries",
+      "Close remaining positions",
+      "Log trades and review"
+    ]
+  },
+
+  "notes": "Intraday framework combining VWAP (trend filter + mean reversion anchor), Volume Profile (key levels), and Price Action (confirmation). Three setup types: trend continuation, mean reversion, and breakout. All trades closed by session end."
 }

--- a/rules.json
+++ b/rules.json
@@ -1,5 +1,5 @@
 {
-  "watchlist": ["BTCUSDT"],
+  "watchlist": ["DELTAIN:BTCUSD.P"],
   "default_timeframe": "15",
 
   "strategy": {

--- a/vp-levels.pine
+++ b/vp-levels.pine
@@ -1,0 +1,69 @@
+//@version=6
+indicator("VP Levels (POC/VAH/VAL)", overlay=true, max_lines_count=3, max_labels_count=3)
+
+numRows   = input.int(50, "Number of Rows", minval=10, maxval=200)
+vaPercent = input.float(70.0, "Value Area %", minval=50, maxval=90) / 100.0
+
+var float[] volAtRow = array.new_float(numRows, 0.0)
+var float  sessionHigh = na
+var float  sessionLow  = na
+var line   pocLine = na, var line vahLine = na, var line valLine = na
+var label  pocLbl  = na, var label vahLbl  = na, var label valLbl  = na
+
+isNewSession = ta.change(time("D")) != 0
+
+if isNewSession
+    array.fill(volAtRow, 0.0)
+    sessionHigh := high
+    sessionLow  := low
+
+sessionHigh := math.max(nz(sessionHigh, high), high)
+sessionLow  := math.min(nz(sessionLow, low), low)
+
+rowSize = (sessionHigh - sessionLow) / numRows
+if rowSize > 0
+    row = math.min(math.floor((close - sessionLow) / rowSize), numRows - 1)
+    array.set(volAtRow, row, array.get(volAtRow, row) + volume)
+
+pocRow    = 0
+pocVol    = 0.0
+totalVol  = 0.0
+for i = 0 to numRows - 1
+    v = array.get(volAtRow, i)
+    totalVol += v
+    if v > pocVol
+        pocVol := v
+        pocRow := i
+
+pocPrice = sessionLow + (pocRow + 0.5) * rowSize
+
+vaTarget = totalVol * vaPercent
+vaVol    = pocVol
+hiRow    = pocRow
+loRow    = pocRow
+while vaVol < vaTarget and (hiRow < numRows - 1 or loRow > 0)
+    upVol = hiRow < numRows - 1 ? array.get(volAtRow, hiRow + 1) : 0.0
+    dnVol = loRow > 0           ? array.get(volAtRow, loRow - 1) : 0.0
+    if upVol >= dnVol and hiRow < numRows - 1
+        hiRow += 1
+        vaVol += upVol
+    else if loRow > 0
+        loRow -= 1
+        vaVol += dnVol
+    else
+        break
+
+vahPrice = sessionLow + (hiRow + 1) * rowSize
+valPrice = sessionLow + loRow * rowSize
+
+if barstate.islast
+    line.delete(pocLine), line.delete(vahLine), line.delete(valLine)
+    label.delete(pocLbl), label.delete(vahLbl), label.delete(valLbl)
+
+    pocLine := line.new(bar_index - 20, pocPrice, bar_index, pocPrice, color=color.orange, width=2, style=line.style_solid)
+    vahLine := line.new(bar_index - 20, vahPrice, bar_index, vahPrice, color=color.teal,   width=1, style=line.style_dashed)
+    valLine := line.new(bar_index - 20, valPrice, bar_index, valPrice, color=color.teal,   width=1, style=line.style_dashed)
+
+    pocLbl := label.new(bar_index, pocPrice, "POC " + str.tostring(pocPrice, format.mintick), style=label.style_none, textcolor=color.orange, size=size.small)
+    vahLbl := label.new(bar_index, vahPrice, "VAH " + str.tostring(vahPrice, format.mintick), style=label.style_none, textcolor=color.teal,   size=size.small)
+    valLbl := label.new(bar_index, valPrice, "VAL " + str.tostring(valPrice, format.mintick), style=label.style_none, textcolor=color.teal,   size=size.small)


### PR DESCRIPTION
## Summary
- Replace the 10-second momentum scalper with an intraday VWAP + Volume Profile + Price Action framework in `rules.json`
- Add `intraday-analyzer.js` — connects to live TradingView chart via MCP and generates structured trade plans (bias, levels, setups with entries/targets/stops)
- Three setup types: trend continuation (pullback to VWAP/VP levels), mean reversion (VWAP ±2σ extremes), and breakouts (VAH/VAL breaks with retest)

## Test plan
- [ ] Run `node intraday-analyzer.js` with TradingView open (VWAP + Volume Profile indicators on 15m chart)
- [ ] Verify VWAP position detection (above/below/extended)
- [ ] Verify Volume Profile level parsing (POC, VAH, VAL from Pine labels)
- [ ] Verify price action pattern detection (engulfing, hammer, inside bar)
- [ ] Confirm bias determination matches visual chart assessment
- [ ] Test with `--symbol` and `--timeframe` flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)