### PR TITLE
Add .claude/launch.json for MCP server and CLI dev configs

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "mcp-server",
+      "runtimeExecutable": "/usr/local/bin/node",
+      "runtimeArgs": ["src/server.js"],
+      "port": 9222
+    },
+    {
+      "name": "tv-cli",
+      "runtimeExecutable": "/usr/local/bin/node",
+      "runtimeArgs": ["src/cli/index.js"],
+      "port": 9222
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds `.claude/launch.json` with two named dev-server configurations so contributors using Claude Code can launch the MCP bridge and CLI from the built-in dev-server picker (`preview_start`) instead of dropping to a terminal.

- **mcp-server** — `node src/server.js` (the CDP bridge to TradingView Desktop on port 9222)
- **tv-cli** — `node src/cli/index.js` (the TradingView CLI tool)

Both bind to port 9222 since they connect to the same TradingView Desktop CDP endpoint — only one runs at a time.

## Notes for reviewers

- `runtimeExecutable` uses the absolute path `/usr/local/bin/node` to make the spawn work regardless of the shell environment Claude Code inherits when starting the dev server. If you'd prefer to keep it portable across machines, swapping to plain `node` is fine — that just requires `node` to be on the PATH of the spawning shell.
- No code changes; this is purely Claude Code configuration metadata.

## Test plan

- [ ] Open the repo in Claude Code and trigger the dev-server picker
- [ ] Start `mcp-server` and confirm it binds to port 9222
- [ ] Stop it, start `tv-cli`, confirm the CLI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)