### PR TITLE
Fix eight bugs in TradingView launch / CDP-connection path

### DIFF
--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -7,13 +7,15 @@ register('status', {
 });
 
 register('launch', {
-  description: 'Launch TradingView with CDP enabled',
+  description: 'Launch TradingView with CDP enabled (no-ops if already running with CDP — pass --force to override)',
   options: {
     port: { type: 'string', short: 'p', description: 'CDP port (default 9222)' },
     'no-kill': { type: 'boolean', description: 'Do not kill existing instances' },
+    force: { type: 'boolean', description: 'Force relaunch even if TradingView already has CDP enabled' },
   },
   handler: (opts) => core.launch({
     port: opts.port ? Number(opts.port) : undefined,
     kill_existing: !opts['no-kill'],
+    force: !!opts.force,
   }),
 });

--- a/src/connection.js
+++ b/src/connection.js
@@ -3,9 +3,14 @@ import CDP from 'chrome-remote-interface';
 let client = null;
 let targetInfo = null;
 const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+// Mutable so tv_launch can override; defaults to TradingView Desktop's conventional port.
+let cdpPort = 9222;
 const MAX_RETRIES = 5;
 const BASE_DELAY = 500;
+
+export function setCdpPort(p) { if (Number.isFinite(p) && p > 0) cdpPort = p; }
+export function getCdpPort() { return cdpPort; }
+export function getCdpHost() { return CDP_HOST; }
 
 // Known direct API paths discovered via live probing (see PROBE_RESULTS.md)
 const KNOWN_PATHS = {
@@ -31,10 +36,23 @@ export { KNOWN_PATHS };
 export async function getClient() {
   if (client) {
     try {
-      // Quick liveness check
+      // Liveness: cheap eval + confirm the cached target still exists at the same URL family.
+      // Why both: when TradingView navigates inside the same tab (e.g. home → /chart/...),
+      // the target id stays the same but window globals reset. evaluate('1') still succeeds,
+      // and the caller then hits "TradingViewApi is undefined" on the next call. Re-fetching
+      // /json/list catches drift in URL + confirms the target is still listed.
       await client.Runtime.evaluate({ expression: '1', returnByValue: true });
+      const resp = await fetch(`http://${CDP_HOST}:${cdpPort}/json/list`);
+      const targets = await resp.json();
+      const current = targets.find(t => t.id === targetInfo?.id);
+      if (!current || !/tradingview/i.test(current.url)) {
+        throw new Error('cached CDP target navigated away or no longer matches TradingView');
+      }
+      // Keep targetInfo URL in sync so downstream consumers see the new URL.
+      targetInfo = current;
       return client;
     } catch {
+      try { await client.close(); } catch {}
       client = null;
       targetInfo = null;
     }
@@ -51,12 +69,27 @@ export async function connect() {
         throw new Error('No TradingView chart target found. Is TradingView open with a chart?');
       }
       targetInfo = target;
-      client = await CDP({ host: CDP_HOST, port: CDP_PORT, target: target.id });
+      client = await CDP({ host: CDP_HOST, port: cdpPort, target: target.id });
 
       // Enable required domains
       await client.Runtime.enable();
       await client.Page.enable();
       await client.DOM.enable();
+
+      // Boot-time race guard: during cold start TradingView's first page is `/` (home) and only
+      // later navigates to /chart/...; the chart API globals (`TradingViewApi`) aren't initialised
+      // on the home page. If they're missing, drop this client and retry — by the next pass the
+      // page will likely have navigated and findChartTarget will pick the real chart target.
+      const apiReady = await client.Runtime.evaluate({
+        expression: "typeof window.TradingViewApi !== 'undefined' && !!window.TradingViewApi._activeChartWidgetWV",
+        returnByValue: true,
+      });
+      if (!apiReady.result?.value) {
+        try { await client.close(); } catch {}
+        client = null;
+        targetInfo = null;
+        throw new Error('Connected to a TradingView tab but the chart API is not ready yet (likely the home/login page).');
+      }
 
       return client;
     } catch (err) {
@@ -69,9 +102,11 @@ export async function connect() {
 }
 
 async function findChartTarget() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${CDP_HOST}:${cdpPort}/json/list`);
   const targets = await resp.json();
-  // Prefer targets with tradingview.com/chart in the URL
+  // Prefer targets actually showing a chart. Fall back to any TradingView tab only if no chart
+  // tab exists — the chart-API readiness probe in connect() catches the case where we picked
+  // a home-page tab during boot.
   return targets.find(t => t.type === 'page' && /tradingview\.com\/chart/i.test(t.url))
     || targets.find(t => t.type === 'page' && /tradingview/i.test(t.url))
     || null;

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -1,9 +1,58 @@
 /**
  * Core health/discovery/launch logic.
  */
-import { getClient, getTargetInfo, evaluate } from '../connection.js';
+import { getClient, getTargetInfo, evaluate, setCdpPort, getCdpPort } from '../connection.js';
 import { existsSync } from 'fs';
 import { execSync, spawn } from 'child_process';
+import net from 'net';
+
+// Quick non-blocking TCP probe: is anything listening on (127.0.0.1, port)?
+function probePort(port, timeoutMs = 500) {
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const done = (ok) => { socket.destroy(); resolve(ok); };
+    socket.setTimeout(timeoutMs);
+    socket.once('connect', () => done(true));
+    socket.once('timeout', () => done(false));
+    socket.once('error', () => done(false));
+    socket.connect(port, '127.0.0.1');
+  });
+}
+
+// Diagnose why CDP isn't reachable: is TradingView even running? Is the port open?
+// Returns a plain object suitable for surfacing in tool errors.
+export async function diagnoseLocalTv(port = getCdpPort()) {
+  const platform = process.platform;
+  let tvPid = null;
+  try {
+    if (platform === 'win32') {
+      const out = execSync('tasklist /FI "IMAGENAME eq TradingView.exe" /NH', { timeout: 3000 }).toString();
+      const m = out.match(/TradingView\.exe\s+(\d+)/);
+      if (m) tvPid = parseInt(m[1], 10);
+    } else {
+      // Narrow to the actual app binary, not helper renderers or this MCP server.
+      const pattern = platform === 'darwin' ? '/MacOS/TradingView$' : 'tradingview';
+      const out = execSync(`pgrep -f '${pattern}'`, { timeout: 3000 }).toString().trim();
+      if (out) tvPid = parseInt(out.split('\n')[0], 10);
+    }
+  } catch { /* not running, or pgrep/tasklist missing */ }
+  const cdpListening = await probePort(port);
+  return { tv_running: tvPid != null, tv_pid: tvPid, cdp_port: port, cdp_listening: cdpListening };
+}
+
+// Human-readable hint derived from a diagnostic result.
+export function hintForDiagnostic(diag) {
+  if (!diag.tv_running && !diag.cdp_listening) {
+    return 'TradingView is not running. Call tv_launch to start it with CDP enabled.';
+  }
+  if (diag.tv_running && !diag.cdp_listening) {
+    return `TradingView (PID ${diag.tv_pid}) is running but was started without Chrome DevTools Protocol on port ${diag.cdp_port}. To fix: quit TradingView (save your layout first — tv_launch will force-kill it), then call tv_launch, or relaunch manually with --remote-debugging-port=${diag.cdp_port}.`;
+  }
+  if (!diag.tv_running && diag.cdp_listening) {
+    return `Port ${diag.cdp_port} is in use but TradingView is not running — another Chromium/Electron process may be holding the port. Free it or pass a different port to tv_launch.`;
+  }
+  return `CDP is listening on port ${diag.cdp_port} but no TradingView chart target was found. Open a chart in the app (not the home screen) and retry.`;
+}
 
 export async function healthCheck() {
   await getClient();
@@ -159,10 +208,30 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing } = {}) {
+export async function launch({ port, kill_existing, force } = {}) {
   const cdpPort = port || 9222;
+  // Default behaviour: be conservative about killing the user's running TradingView.
+  // kill_existing controls whether we kill at all; `force` skips the "already running with CDP" short-circuit.
   const killFirst = kill_existing !== false;
   const platform = process.platform;
+
+  // Persist the chosen port so subsequent tool calls (which go through getClient/findChartTarget)
+  // hit the right port instead of the hardcoded 9222 default.
+  setCdpPort(cdpPort);
+
+  // Smart short-circuit: if TradingView is already running AND CDP is already listening on the
+  // requested port, don't kill+relaunch — that would force the user to re-sign-in and lose any
+  // unsaved layout state. Just report success and let the caller proceed.
+  if (!force) {
+    const pre = await diagnoseLocalTv(cdpPort);
+    if (pre.tv_running && pre.cdp_listening) {
+      return {
+        success: true, platform, already_running: true, pid: pre.tv_pid,
+        cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`, cdp_ready: true,
+        note: 'TradingView was already running with CDP enabled — skipped relaunch to preserve your session. Pass { force: true } to force a restart.',
+      };
+    }
+  }
 
   const pathMap = {
     darwin: [
@@ -213,16 +282,43 @@ export async function launch({ port, kill_existing } = {}) {
 
   if (killFirst) {
     try {
-      if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
-      else execSync('pkill -f TradingView', { timeout: 5000 });
+      if (platform === 'win32') {
+        execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
+      } else if (platform === 'darwin') {
+        // Narrow match: only the main app binary, not the project path (which may contain
+        // "tradingview") nor helper renderers (which will exit when the parent does anyway).
+        execSync("pkill -f '/MacOS/TradingView$'", { timeout: 5000 });
+      } else {
+        // On Linux the binary path varies; match common installation patterns but stay narrow
+        // enough to not nuke unrelated processes that happen to contain "tradingview".
+        execSync("pkill -f '(^|/)(TradingView|tradingview)( |$)'", { timeout: 5000 });
+      }
       await new Promise(r => setTimeout(r, 1500));
     } catch { /* may not be running */ }
   }
 
-  const child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+  // Launch strategy by platform:
+  //   - macOS: use `open -na` so the app goes through LaunchServices (proper Dock icon, Gatekeeper
+  //     ack, no half-foregrounded state). Note: `open` exits immediately, so child.pid is the open
+  //     helper, not TradingView itself — we recover the real PID via diagnoseLocalTv after CDP is up.
+  //   - Windows / Linux: spawn the binary directly with the flag.
+  let child;
+  let appBundle = null;
+  if (platform === 'darwin') {
+    appBundle = tvPath.replace(/\/Contents\/MacOS\/TradingView$/, '');
+    child = spawn('open', ['-na', appBundle, '--args', `--remote-debugging-port=${cdpPort}`],
+      { detached: true, stdio: 'ignore' });
+  } else {
+    child = spawn(tvPath, [`--remote-debugging-port=${cdpPort}`], { detached: true, stdio: 'ignore' });
+  }
   child.unref();
 
-  for (let i = 0; i < 15; i++) {
+  // Cold-start TradingView Desktop (sign-in, layout restore, network warmup) routinely takes
+  // 30–60 s before CDP starts accepting connections. The old 15 s budget returned success:true
+  // with a warning, which most callers ignored — then the next tool call would hit a dead port.
+  // We now poll up to 60 s and return success:false if CDP never comes up.
+  const READY_TIMEOUT_S = 60;
+  for (let i = 0; i < READY_TIMEOUT_S; i++) {
     await new Promise(r => setTimeout(r, 1000));
     try {
       const http = await import('http');
@@ -235,17 +331,26 @@ export async function launch({ port, kill_existing } = {}) {
       });
       if (ready) {
         const info = JSON.parse(ready);
+        // On macOS, child.pid is the `open` helper which has already exited — resolve the real
+        // TradingView pid via the same diagnostic helper used everywhere else.
+        const realPid = platform === 'darwin'
+          ? (await diagnoseLocalTv(cdpPort)).tv_pid
+          : child.pid;
         return {
-          success: true, platform, binary: tvPath, pid: child.pid,
+          success: true, platform, binary: tvPath, app_bundle: appBundle, pid: realPid,
           cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
+          cdp_ready: true, waited_seconds: i + 1,
           browser: info.Browser, user_agent: info['User-Agent'],
         };
       }
     } catch { /* retry */ }
   }
 
+  const failPid = platform === 'darwin' ? (await diagnoseLocalTv(cdpPort)).tv_pid : child.pid;
   return {
-    success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
-    warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
+    success: false, platform, binary: tvPath, app_bundle: appBundle, pid: failPid,
+    cdp_port: cdpPort, cdp_ready: false, waited_seconds: READY_TIMEOUT_S,
+    error: `TradingView ${failPid ? `(PID ${failPid}) ` : ''}spawned but CDP did not start listening on port ${cdpPort} within ${READY_TIMEOUT_S}s.`,
+    hint: 'The app may still be signing in or restoring layouts. Wait ~30s and call tv_health_check. If it still fails, the binary may not support --remote-debugging-port (TV < v2.14) — check Activity Monitor and relaunch manually.',
   };
 }

--- a/src/core/tab.js
+++ b/src/core/tab.js
@@ -2,16 +2,13 @@
  * Core tab management logic.
  * Controls TradingView Desktop tabs via CDP and Electron keyboard shortcuts.
  */
-import { getClient, evaluate } from '../connection.js';
-
-const CDP_HOST = 'localhost';
-const CDP_PORT = 9222;
+import { getClient, evaluate, getCdpHost, getCdpPort } from '../connection.js';
 
 /**
  * List all open chart tabs (CDP page targets).
  */
 export async function list() {
-  const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/list`);
+  const resp = await fetch(`http://${getCdpHost()}:${getCdpPort()}/json/list`);
   const targets = await resp.json();
 
   const tabs = targets
@@ -97,7 +94,7 @@ export async function switchTab({ index }) {
 
   // Use CDP Target.activateTarget to bring the tab to front
   try {
-    const resp = await fetch(`http://${CDP_HOST}:${CDP_PORT}/json/activate/${target.id}`);
+    const resp = await fetch(`http://${getCdpHost()}:${getCdpPort()}/json/activate/${target.id}`);
     const text = await resp.text();
     return { success: true, action: 'switched', index: idx, tab_id: target.id, chart_id: target.chart_id };
   } catch (e) {

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -5,7 +5,17 @@ import * as core from '../core/health.js';
 export function registerHealthTools(server) {
   server.tool('tv_health_check', 'Check CDP connection to TradingView and return current chart state', {}, async () => {
     try { return jsonResult(await core.healthCheck()); }
-    catch (err) { return jsonResult({ success: false, error: err.message, hint: 'TradingView is not running with CDP enabled. Use the tv_launch tool to start it automatically.' }, true); }
+    catch (err) {
+      // On failure, probe local state (is TV running? is the port open?) so the user sees the
+      // actual reason instead of a generic "fetch failed" / "no target" message.
+      let diagnostic = null;
+      let hint = 'TradingView is not running with CDP enabled. Use the tv_launch tool to start it automatically.';
+      try {
+        diagnostic = await core.diagnoseLocalTv();
+        hint = core.hintForDiagnostic(diagnostic);
+      } catch { /* diagnostic is best-effort */ }
+      return jsonResult({ success: false, error: err.message, diagnostic, hint }, true);
+    }
   });
 
   server.tool('tv_discover', 'Report which known TradingView API paths are available and their methods', {}, async () => {
@@ -18,11 +28,12 @@ export function registerHealthTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux.', {
+  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux. If TradingView is already running with CDP, returns success without restarting (pass force:true to override).', {
     port: z.coerce.number().optional().describe('CDP port (default 9222)'),
     kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
-  }, async ({ port, kill_existing }) => {
-    try { return jsonResult(await core.launch({ port, kill_existing })); }
+    force: z.coerce.boolean().optional().describe('Force relaunch even if TradingView is already running with CDP (default false). WARNING: kills the running app — save your layout first.'),
+  }, async ({ port, kill_existing, force }) => {
+    try { return jsonResult(await core.launch({ port, kill_existing, force })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }


### PR DESCRIPTION
## Summary

Eight bugs in the launch / CDP-connection path that caused `tv_health_check` to fail with generic "fetch failed" / "no chart target found" errors and made `tv_launch` unreliable across cold boot, in-tab navigation, and the "already-running" case.

## What changed

| # | Bug | Fix |
|---|---|---|
| 1 | `CDP_PORT` hardcoded in `connection.js` — `tv_launch({port:N})` was ignored by every later call | Mutable `cdpPort` + `setCdpPort` / `getCdpPort` / `getCdpHost` exports; `launch()` persists the chosen port |
| 2 | No detection of "already running with CDP" — `tv_launch` always killed the user's session | Smart short-circuit: returns success without restarting if TV is up with CDP on the requested port. New `force: true` opt-in for the old behaviour |
| 3 | 15 s readiness poll returned `success: true` on timeout (most callers ignored the warning) | Bumped to 60 s; timeout returns `success: false` with an actionable error + hint |
| 4 | Cached CDP client survived in-tab navigation (home → /chart) → opaque "target closed" errors later | `getClient()` re-fetches `/json/list` and confirms the cached target id + URL still match a TradingView page |
| 5 | `findChartTarget` could bind to the `/` (home) tab during cold boot — `chart.symbol()` then threw | After CDP attach, probe `TradingViewApi._activeChartWidgetWV`; reject + retry if the chart API isn't initialised yet |
| 6 | `pkill -f TradingView` was overly broad — would match anything with "TradingView" in its path | macOS: `pkill -f '/MacOS/TradingView$'`. Linux: scoped regex. Helpers exit when the parent does anyway |
| 7 | `tv_health_check` failure gave only "fetch failed" — no diagnostic | New `diagnoseLocalTv()` (TCP probe + pgrep/tasklist) + `hintForDiagnostic()`. Tool wrapper attaches both to the error response |
| 8 | Raw `spawn(binary, …)` on macOS bypassed LaunchServices — Gatekeeper, Dock association, and app singleton-lock were all unpredictable | macOS: `open -na <bundle> --args --remote-debugging-port=…`. Real PID resolved via `diagnoseLocalTv` after CDP is up. Windows/Linux unchanged |

## Files

```
src/cli/commands/health.js |   4 +-
src/connection.js          |  45 +++++++++++++++--
src/core/health.js         | 123 ++++++++++++++++++++++++++++++++++++++++----
src/core/tab.js            |   9 ++--
src/tools/health.js        |  19 +++++--
5 files changed, 175 insertions(+), 25 deletions(-)
```

## Verified

- `node --check` passes on every patched file.
- `diagnoseLocalTv()` smoke-tested live against a running-without-CDP scenario: correctly identified `tv_running=true, tv_pid=…, cdp_listening=false` and produced an actionable hint ("TradingView (PID …) is running but was started without Chrome DevTools Protocol on port 9222. To fix: …").
- `tv launch --help` and `tv --help` render the updated descriptions.
- The pre-existing `tests/cli.test.js "pine check returns errors"` failure reproduces on `main` without these changes — unrelated to this PR.

## Reviewer notes

- `getClient()` now does one extra `fetch('/json/list')` per cached-client reuse. Sub-millisecond locally; negligible compared to the CDP `Runtime.evaluate` that follows.
- On macOS, `child.pid` from `spawn('open', …)` is the helper process and exits immediately. The real TradingView PID is resolved via `diagnoseLocalTv` after CDP is up, and surfaced in the return value as `pid`.
- Default behaviour of `tv_launch` is now non-destructive: if TradingView is already up with CDP, it returns success and leaves the session alone. Pass `force: true` for the old "kill and relaunch" behaviour.
- All references to a hardcoded `9222` are now either the single source of truth (`let cdpPort = 9222` in `connection.js`) or argument-schema defaults / doc strings — nothing bypasses the dynamic port at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
