### PR TITLE
Write-tool mutex for state isolation + optional NDJSON tracer

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,25 @@ Full command list: `tv --help`
 | `morning_brief` — watchlist empty | Add symbols to the `watchlist` array in `rules.json` |
 | Tools return stale data | TradingView still loading — wait a few seconds |
 | Pine Editor tools fail | Open Pine Editor panel first: `ui_open_panel pine-editor open` |
+| Need to inspect tool-call traffic / latency / mutex contention | Enable the NDJSON packet tracer: set `MCP_TRACE_FILE=/tmp/mcp-trace.log` in the server environment, then `tail -F` the file. See [`docs/TRACING.md`](docs/TRACING.md) for schema, env vars, rotation, and analysis recipes. |
+
+### Packet tracing for diagnostics
+
+This fork ships an optional NDJSON tracer ([`src/tracer.js`](src/tracer.js)) that records every CDP `evaluate` / `evaluateWrite` call — including the originating MCP tool name, JS expression excerpt, duration, and (for writes) mutex queue wait time and critical-section duration. It's **off by default and zero-cost when off**.
+
+Activate by setting `MCP_TRACE_FILE` in the server's environment:
+
+```bash
+MCP_TRACE_FILE=/tmp/mcp-trace.log node src/server.js
+```
+
+Sample one-liner to watch mutex contention live:
+
+```bash
+tail -F /tmp/mcp-trace.log | jq -r 'select(.kind=="evaluateWrite.acquired") | "wait=\(.wait_ms)ms  tool=\(.tool // "?")"'
+```
+
+Full activation guide, NDJSON schema, env-var reference, multi-process safety notes, and jq analysis recipes: **[docs/TRACING.md](docs/TRACING.md)**.
 
 ---
 

--- a/docs/TRACING.md
+++ b/docs/TRACING.md
@@ -1,0 +1,166 @@
+# MCP Packet Tracing
+
+Optional NDJSON trace of every CDP `evaluate()` and `evaluateWrite()` call inside the MCP server. Disabled by default; turn it on by setting one environment variable. Useful for:
+
+- **Troubleshooting** — see exactly which tool a slow/failing CDP call belongs to, what JS it evaluated, and how long it took.
+- **Latency profiling** — measure tool-call distributions over time without bolting on an APM.
+- **Mutex visibility** — when the write-tool mutex queues calls, the trace exposes `wait_ms` (queue latency) and `work_ms` (critical-section duration) per call.
+- **Operational forensics** — after an incident, replay exactly which Chrome calls fired and in what order.
+
+The tracer is implemented in [`src/tracer.js`](../src/tracer.js). It is **off by default and zero-cost when off** — `evaluate()` / `evaluateWrite()` skip the trace branch in a single `if`. Tests live at [`tests/tracer.test.js`](../tests/tracer.test.js).
+
+## Activate
+
+```bash
+# Minimal — write events to /tmp/mcp-trace.log
+MCP_TRACE_FILE=/tmp/mcp-trace.log node src/server.js
+
+# Tune the buffer + rotation
+MCP_TRACE_FILE=/tmp/mcp-trace.log \
+MCP_TRACE_BUFFER_MS=50 \
+MCP_TRACE_MAX_MB=50 \
+node src/server.js
+```
+
+When deployed as a launchd / systemd service, add to the service's environment block.
+
+## Env vars
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `MCP_TRACE_FILE` | unset → **disabled** | NDJSON output path. Created if missing; appended otherwise. |
+| `MCP_TRACE_MAX_MB` | `50` | Rotation threshold. When the file exceeds this, it's renamed to `<path>.1` (replacing any prior `.1`) and a fresh file is started. Single-level rotation only. |
+| `MCP_TRACE_BUFFER_MS` | `50` | Internal flush interval (ms). Events are buffered in memory and flushed on this timer or when the buffer hits 64KB, whichever comes first. Plus a final flush on `process.beforeExit`. |
+| `MCP_TRACE_SAMPLE` | `1.0` | Probabilistic sampling fraction `[0, 1]`. Set to `0.1` in high-volume production to cap trace volume. Sampling decision is per-span at start, so partial spans never appear. |
+| `MCP_TRACE_DEBUG` | unset | When set, trace internal errors (disk full, rotation failure) print to stderr instead of being swallowed silently. |
+
+## Output schema (NDJSON)
+
+Each line is one JSON object terminated by `\n`. Multi-process safe: POSIX `write()` calls under PIPE_BUF (4KB) are atomic, and lines stay well under that. Multiple MCP subprocesses appending to the same file interleave cleanly at line granularity.
+
+Fields:
+
+| Field | Type | Always present? | Meaning |
+|---|---|---|---|
+| `ts` | string (ISO 8601) | yes | Event timestamp |
+| `pid` | number | yes | Emitting process PID — useful to separate concurrent MCP subprocesses |
+| `seq` | number | yes | Per-process monotonic sequence (starts at 1, increments per emitted line) |
+| `kind` | string | yes | Event kind (see table below) |
+| `id` | number | for span events | Span identifier — `start`/`end` of one logical call share the same `id` |
+| `tool` | string | when attribution is active | MCP tool name (`chart_set_symbol`, `quote_get`, etc.) — attributed via the `withToolName` wrapper applied in `src/server.js` to every registered tool handler |
+| `excerpt` | string | on `*.start` and `*.queued` events | First 80 chars of the JS expression (whitespace collapsed). Lets you tell at a glance which code path fired. |
+| `dur_ms` | number | on `evaluate.end` and `evaluate.error` | Wall-clock duration of the underlying CDP call |
+| `wait_ms` | number | on `evaluateWrite.acquired` | Time spent waiting in the mutex queue before this writer was granted the lock |
+| `work_ms` | number | on `evaluateWrite.released` | Critical-section duration — how long the CDP work itself took inside the lock |
+| `error` | string | on `*.error` | Truncated error message (200 char cap) |
+
+Event kinds:
+
+| Kind | Emitted by | What it means |
+|---|---|---|
+| `evaluate.start` | `evaluate()` | A read-class CDP call began |
+| `evaluate.end` | `evaluate()` | Read completed normally |
+| `evaluate.error` | `evaluate()` | Read threw — `error` field has the message |
+| `evaluateWrite.queued` | `evaluateWrite()` | Single-evaluate write call entered the wrapper and is now queued behind the mutex |
+| `evaluateWrite.acquired` | `evaluateWrite()` | Mutex granted to this writer; `wait_ms` shows the queue latency |
+| `evaluateWrite.released` | `evaluateWrite()` | Inner CDP call returned and the mutex was released; `work_ms` shows critical-section time |
+| `evaluateWrite.error` | `evaluateWrite()` | Inner CDP call threw — `error` field has the message |
+| `writeLock.queued` | `withWriteLock(fn)` | Multi-step write SECTION entered the wrapper; queued behind the mutex |
+| `writeLock.acquired` | `withWriteLock(fn)` | Mutex granted to this section; `wait_ms` = queue latency. The inner `fn` may now issue multiple `evaluate` calls (recorded as `evaluate.*` events) atomically under the lock. |
+| `writeLock.released` | `withWriteLock(fn)` | Section finished; `work_ms` = total time the lock was held (covers all inner evaluate calls + sleeps + JS work) |
+| `writeLock.error` | `withWriteLock(fn)` | Inner section threw |
+
+## Sample analysis (jq)
+
+```bash
+TRACE=/tmp/mcp-trace.log
+
+# 1) Distribution of mutex acquire times.
+#    A healthy single-MCP run should see most values <1ms.
+jq -r 'select(.kind=="evaluateWrite.acquired") | .wait_ms' "$TRACE" \
+  | sort -n \
+  | awk '{a[NR]=$1} END {
+      print "count:", NR;
+      print "p50:  ", a[int(NR*0.5)];
+      print "p95:  ", a[int(NR*0.95)];
+      print "p99:  ", a[int(NR*0.99)];
+      print "max:  ", a[NR];
+    }'
+
+# 2) Calls per tool (requires tool attribution).
+jq -r 'select(.kind=="evaluate.start" or .kind=="evaluateWrite.queued")
+       | .tool // "unattributed"' "$TRACE" \
+  | sort | uniq -c | sort -rn
+
+# 3) Outliers — reads taking longer than 50ms.
+jq 'select(.kind=="evaluate.end" and .dur_ms > 50)' "$TRACE"
+
+# 4) Time-series of mutex contention.
+#    Each line: timestamp, wait_ms. Plot in your tool of choice.
+jq -r 'select(.kind=="evaluateWrite.acquired")
+       | [.ts, .wait_ms] | @tsv' "$TRACE"
+
+# 5) Errors.
+jq 'select(.kind | endswith(".error"))' "$TRACE"
+
+# 6) Find concurrent writer races across processes —
+#    pairs of evaluateWrite.queued events that overlap in wall time.
+#    Within one PID the mutex serializes, but across PIDs (legacy
+#    stdio-per-consumer pattern) they can race in Chrome.
+jq -s 'map(select(.kind=="evaluateWrite.queued"))
+       | group_by(.pid)
+       | length as $n
+       | if $n > 1 then "multiple PIDs writing: \($n)" else "single PID" end' "$TRACE"
+
+# 7) Live tail with friendly formatting.
+tail -F "$TRACE" \
+  | jq -r 'select(.kind | startswith("evaluateWrite"))
+           | [.ts[11:19], .pid, .kind, .tool // "-",
+              (.wait_ms // .work_ms // "" | tostring)] | @tsv'
+```
+
+## Multi-process notes
+
+Each MCP subprocess writes to the same file. Lines interleave by completion order. To analyse a single process in isolation, filter by `pid`:
+
+```bash
+jq 'select(.pid == 16220)' "$TRACE"
+```
+
+The `seq` field is **per-process**, not global — two different PIDs can both have `seq: 5`. Use the `ts` for global ordering.
+
+## Performance
+
+The tracer is asynchronous and buffered. Concretely:
+
+- Each call adds one JSON line to an in-memory array.
+- The flush timer (default 50ms) writes the accumulated batch as one `fs.appendFile` call.
+- The buffer also flushes synchronously when it hits 64KB.
+
+When `MCP_TRACE_FILE` is unset (default), the trace code paths in `src/connection.js` short-circuit to a no-op stub before any string formatting or memory allocation. The cost is one `if (!config().enabled)` check per call — effectively free.
+
+When the tracer is active, the per-call cost is dominated by `JSON.stringify` of the event object — typically a few microseconds. Disk write is amortised across the buffer interval.
+
+## Rotation
+
+When the trace file exceeds `MCP_TRACE_MAX_MB`, it's renamed to `<path>.1` (overwriting any prior `.1`) and a fresh empty file starts. **Single-level rotation, no compression.** This is intentionally minimal — for long-term retention pipe through logrotate, or run a sidecar that rotates by date.
+
+## When to enable
+
+| Scenario | Recommended setting |
+|---|---|
+| Local debugging — see what tools an agent called | `MCP_TRACE_FILE=/tmp/mcp-trace.log` |
+| Production with periodic forensics | `MCP_TRACE_FILE=/var/log/mcp/trace.log` + `MCP_TRACE_MAX_MB=200` |
+| High-volume production — keep volume cap | Add `MCP_TRACE_SAMPLE=0.1` to retain 10% of spans |
+| Investigating a specific incident | Enable just before reproducing, disable after — no service restart needed if you can set env on the next subprocess spawn |
+
+## Disabling
+
+Unset the env var. Restart the server (or, for spawn-per-call patterns where each subprocess reads env at start, the next subprocess spawn picks up the absence and is tracer-free).
+
+## Limitations
+
+- Tracer state (buffer, counter) is per-OS-process. Long-running daemons keep their buffer in memory; short-lived spawn-per-query subprocesses flush + exit cleanly via `beforeExit`.
+- `SIGKILL` (kill -9) and OOM kills lose any unflushed events. `SIGTERM` flushes via the `beforeExit` hook (Node's default lifecycle handles this).
+- Rotation is not atomic relative to concurrent writers in other processes — if two MCPs both check size at the same moment, one might write to the (just-rotated) `.1`. This is rare and acceptable for diagnostics use.
+- Sampling drops at the SPAN level (not per-event), so write-span lifecycle events (`queued`/`acquired`/`released`) all emit or none emit for a given call.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",
+        "async-mutex": "^0.5.0",
         "chrome-remote-interface": "^0.33.2",
         "dotenv": "^17.4.1"
       },
@@ -112,6 +113,15 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/async-mutex": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/async-mutex/-/async-mutex-0.5.0.tgz",
+      "integrity": "sha512-1A94B18jkJ3DYq284ohPxoXbfTA5HsQ7/Mf4DEhcyLx3Bz27Rh59iScbB6EPiP+B+joue6YCxcMXSbFC1tZKwA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -1098,6 +1108,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,14 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js tests/tracer.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js tests/tracer.test.js",
     "test:cli": "node --test tests/cli.test.js",
     "test:concurrency": "node --test tests/concurrency.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js",
-    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js",
+    "test:tracer": "node --test tests/tracer.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js tests/tracer.test.js",
+    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js tests/tracer.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -14,16 +14,18 @@
   "scripts": {
     "start": "node src/server.js",
     "tv": "node src/cli/index.js",
-    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js",
+    "test": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js",
     "test:e2e": "node --test tests/e2e.test.js",
-    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js",
+    "test:unit": "node --test tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js",
     "test:cli": "node --test tests/cli.test.js",
-    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js",
-    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js",
+    "test:concurrency": "node --test tests/concurrency.test.js",
+    "test:all": "node --test tests/e2e.test.js tests/pine_analyze.test.js tests/cli.test.js tests/concurrency.test.js",
+    "test:verbose": "node --test --test-reporter=spec tests/e2e.test.js tests/pine_analyze.test.js tests/concurrency.test.js",
     "test:count": "node --test --test-reporter=spec tests/e2e.test.js 2>&1 | tail -5"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "async-mutex": "^0.5.0",
     "chrome-remote-interface": "^0.33.2",
     "dotenv": "^17.4.1"
   }

--- a/scripts/bench-mutex.mjs
+++ b/scripts/bench-mutex.mjs
@@ -1,0 +1,189 @@
+#!/usr/bin/env node
+/**
+ * bench-mutex.mjs — validate F2 write-tool mutex against live Chrome+TV.
+ *
+ * Spawns the MCP server (this fork) as a child process via stdio,
+ * connects as an MCP client, and runs three scenarios:
+ *
+ *   B1 — baseline read latency (10× chart_get_state, sequential)
+ *   B2 — reads do not block on a slow write (1× chart_set_symbol on same
+ *        symbol + 5 parallel quote_get started 50ms later)
+ *   B3 — concurrent writes serialize in arrival order (5 parallel
+ *        scrollToDate calls — chosen because it mutates only the visible
+ *        viewport, no underlying chart data state changes; safe to run
+ *        against the live LENS-polled chart)
+ *
+ * Reports per-call latency, p50/p95, total wall time vs theoretical-
+ * serial, and order observation.
+ *
+ * Pre-requisites:
+ *   - Chrome with TradingView open, CDP listening on :9222
+ *   - `npm install` already run (async-mutex dep present)
+ *
+ * Usage:
+ *   node scripts/bench-mutex.mjs                       # default: XAUUSD
+ *   SYMBOL=BTCUSDT node scripts/bench-mutex.mjs        # benchmark target
+ */
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = join(__dirname, "..", "src", "server.js");
+const SYMBOL = process.env.SYMBOL || "XAUUSD";
+
+function fmt(ms) {
+  return `${ms.toFixed(1)}ms`;
+}
+function percentile(arr, p) {
+  if (arr.length === 0) return 0;
+  const sorted = [...arr].sort((a, b) => a - b);
+  return sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+}
+
+async function callTool(client, name, args = {}) {
+  const t0 = performance.now();
+  const result = await client.callTool({ name, arguments: args });
+  const dt = performance.now() - t0;
+  return { result, dt };
+}
+
+async function main() {
+  console.log(`F2 write-mutex benchmark — symbol=${SYMBOL}\n`);
+
+  const transport = new StdioClientTransport({
+    command: "node",
+    args: [SERVER_PATH],
+  });
+  const client = new Client(
+    { name: "bench-mutex", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+
+  try {
+    // ----- B1 — sequential read baseline -----
+    console.log("## B1 — baseline read latency");
+    const b1_durations = [];
+    for (let i = 0; i < 10; i++) {
+      const { dt } = await callTool(client, "chart_get_state", {});
+      b1_durations.push(dt);
+    }
+    const b1_mean = b1_durations.reduce((a, b) => a + b, 0) / b1_durations.length;
+    const b1_p50 = percentile(b1_durations, 0.5);
+    const b1_p95 = percentile(b1_durations, 0.95);
+    console.log(
+      `  10× chart_get_state — mean ${fmt(b1_mean)}, p50 ${fmt(b1_p50)}, p95 ${fmt(b1_p95)}`,
+    );
+    console.log(
+      `  individual: ${b1_durations.map((d) => fmt(d)).join(", ")}\n`,
+    );
+
+    // ----- B2 — reads do not block on a slow write -----
+    console.log("## B2 — reads do not block on a slow write");
+    const b2_t0 = performance.now();
+    const writePromise = (async () => {
+      const t0 = performance.now();
+      await callTool(client, "chart_set_symbol", { symbol: SYMBOL });
+      return { who: "write_set_symbol", dt: performance.now() - t0, started_at: t0 - b2_t0 };
+    })();
+
+    // Wait 50ms then fire 5 parallel reads
+    await new Promise((r) => setTimeout(r, 50));
+    const readPromises = Array.from({ length: 5 }, async (_, i) => {
+      const t0 = performance.now();
+      await callTool(client, "quote_get", {});
+      return { who: `read_${i + 1}`, dt: performance.now() - t0, started_at: t0 - b2_t0 };
+    });
+
+    const results = await Promise.all([writePromise, ...readPromises]);
+    const sortByCompletion = (a, b) => a.started_at + a.dt - (b.started_at + b.dt);
+    results.sort(sortByCompletion);
+    const writeResult = results.find((r) => r.who === "write_set_symbol");
+    console.log(`  write completion order events (start→end relative ms):`);
+    for (const r of results) {
+      console.log(
+        `    ${r.who.padEnd(20)} start=${fmt(r.started_at)} dur=${fmt(r.dt)} end=${fmt(r.started_at + r.dt)}`,
+      );
+    }
+    const readsCompletedBeforeWrite = results.filter(
+      (r) => r.who.startsWith("read_") && r.started_at + r.dt < writeResult.started_at + writeResult.dt,
+    );
+    console.log(
+      `  → ${readsCompletedBeforeWrite.length}/5 reads completed BEFORE the write finished` +
+        ` (expected 5/5 if read path is mutex-free)\n`,
+    );
+
+    // ----- B3 — concurrent writes serialize in arrival order -----
+    console.log("## B3 — concurrent writes serialize");
+    // scrollToDate dates picked relative-to-now; small range so all
+    // requests are valid for the current symbol's bar history.
+    const now = Math.floor(Date.now() / 1000);
+    const dates = [
+      now - 86400 * 1, // yesterday
+      now - 86400 * 2,
+      now - 86400 * 3,
+      now - 86400 * 4,
+      now - 86400 * 5,
+    ];
+    const b3_t0 = performance.now();
+    const writes = dates.map((d, i) => async () => {
+      const t0 = performance.now();
+      await callTool(client, "chart_scroll_to_date", { date: String(d) });
+      return { i, dt: performance.now() - t0, started_at: t0 - b3_t0, ended_at: performance.now() - b3_t0 };
+    });
+    const writeResults = await Promise.all(writes.map((w) => w()));
+    const b3_total = performance.now() - b3_t0;
+    const b3_sum = writeResults.reduce((s, r) => s + r.dt, 0);
+
+    console.log(`  5× chart_scroll_to_date — wall clock total ${fmt(b3_total)}`);
+    console.log(`  per-call timeline (start→end relative ms):`);
+    for (const r of writeResults) {
+      console.log(
+        `    write_${r.i} start=${fmt(r.started_at)} dur=${fmt(r.dt)} end=${fmt(r.ended_at)}`,
+      );
+    }
+
+    // Order check — serialization shows up in END times, NOT start times.
+    // Promise.all fires every async function's entry simultaneously, so all
+    // start_at values cluster at ~0ms. The mutex queues their critical
+    // sections; the CDP work runs one after another. If the mutex works,
+    // consecutive end times should be spaced by ~one-call-of-work apart.
+    // If writes ran in parallel without mutex, all end times would cluster
+    // close together (every write would finish at roughly the same moment).
+    const byEnd = [...writeResults].sort((a, b) => a.ended_at - b.ended_at);
+    const gaps = [];
+    for (let i = 1; i < byEnd.length; i++) {
+      gaps.push(byEnd[i].ended_at - byEnd[i - 1].ended_at);
+    }
+    const meanGap = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+    const minGap = Math.min(...gaps);
+    const maxGap = Math.max(...gaps);
+    const meanDur = writeResults.reduce((s, r) => s + r.dt, 0) / writeResults.length;
+    const expectedSerialPerCall = writeResults[0].dt; // first call had no wait
+    console.log(
+      `  inter-end gaps: min ${fmt(minGap)}, mean ${fmt(meanGap)}, max ${fmt(maxGap)}`,
+    );
+    console.log(
+      `  first-call duration (no queue wait): ${fmt(expectedSerialPerCall)} — gaps should match this if serialized`,
+    );
+    const serialEvidence =
+      meanGap >= expectedSerialPerCall * 0.7 && meanGap <= expectedSerialPerCall * 1.3;
+    console.log(
+      `  → ${serialEvidence ? "✓" : "✗"} writes serialized: mean inter-end gap (${fmt(meanGap)}) ≈ per-call work (${fmt(expectedSerialPerCall)})`,
+    );
+    if (!serialEvidence) {
+      console.log(
+        `    parallel hypothesis: gaps would be <50ms each (all ending together); observed mean ${fmt(meanGap)}`,
+      );
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((e) => {
+  console.error("Benchmark error:", e);
+  process.exit(1);
+});

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,5 +1,6 @@
 import CDP from 'chrome-remote-interface';
 import { Mutex } from 'async-mutex';
+import { trace } from './tracer.js';
 
 let client = null;
 let targetInfo = null;
@@ -114,6 +115,7 @@ export async function getTargetInfo() {
 }
 
 export async function evaluate(expression, opts = {}) {
+  const span = trace.start('evaluate', expression);
   const c = await getClient();
   const result = await c.Runtime.evaluate({
     expression,
@@ -125,8 +127,10 @@ export async function evaluate(expression, opts = {}) {
     const msg = result.exceptionDetails.exception?.description
       || result.exceptionDetails.text
       || 'Unknown evaluation error';
+    span.error(msg);
     throw new Error(`JS evaluation error: ${msg}`);
   }
+  span.end();
   return result.result?.value;
 }
 
@@ -149,7 +153,18 @@ export async function evaluateAsync(expression) {
  * @returns {Promise<*>} - Same return shape as evaluate().
  */
 export async function evaluateWrite(expression, opts = {}) {
-  return writeMutex.runExclusive(() => evaluate(expression, opts));
+  const span = trace.startWrite(expression);
+  return writeMutex.runExclusive(async () => {
+    span.acquired();
+    try {
+      const r = await evaluate(expression, opts);
+      span.released();
+      return r;
+    } catch (e) {
+      span.error(String(e.message || e));
+      throw e;
+    }
+  });
 }
 
 /**
@@ -167,7 +182,18 @@ export async function evaluateWrite(expression, opts = {}) {
  * @returns {Promise<*>}
  */
 export async function withWriteLock(fn) {
-  return writeMutex.runExclusive(() => fn(evaluate));
+  const span = trace.startSection();
+  return writeMutex.runExclusive(async () => {
+    span.acquired();
+    try {
+      const r = await fn(evaluate);
+      span.released();
+      return r;
+    } catch (e) {
+      span.error(String(e.message || e));
+      throw e;
+    }
+  });
 }
 
 export async function disconnect() {

--- a/src/connection.js
+++ b/src/connection.js
@@ -1,7 +1,36 @@
 import CDP from 'chrome-remote-interface';
+import { Mutex } from 'async-mutex';
 
 let client = null;
 let targetInfo = null;
+
+// Write-tool serialization mutex.
+//
+// Why: stdio MCP and Streamable HTTP both support concurrent in-flight
+// requests; the MCP SDK dispatches handlers as async tasks. CDP itself
+// supports concurrent commands (response matching by id), so two
+// evaluate() calls reach Chrome on the same connection and Chrome's
+// single JS thread runs them in arrival order. For READ tools that's
+// fine. For WRITE tools (chart_set_symbol, chart_set_timeframe,
+// chart_manage_indicator, draw_shape, etc.) interleaving can leave the
+// page in an inconsistent state — e.g. two rapid chart_set_symbol calls
+// from different clients can race on the symbol-load lifecycle and the
+// "winner" depends on Chrome's microtask scheduling rather than arrival
+// order.
+//
+// Solution: evaluateWrite() runs inside a process-wide async mutex.
+// Concurrent writes serialize; reads stay unblocked. The classification
+// is per-handler (see src/core/<module>.js) — handlers calling
+// state-mutating JS expressions use evaluateWrite(); read-only handlers
+// stay on evaluate().
+//
+// Per-instance scope: one MCP server process = one mutex. If you run
+// multiple MCP processes against the same Chrome (legacy stdio
+// per-consumer pattern), the mutex does NOT cross processes — each MCP
+// has its own. The recommended deployment is one MCP process serving
+// multiple consumers via Streamable HTTP, where the mutex covers all
+// callers.
+const writeMutex = new Mutex();
 const CDP_HOST = 'localhost';
 const CDP_PORT = 9222;
 const MAX_RETRIES = 5;
@@ -103,6 +132,42 @@ export async function evaluate(expression, opts = {}) {
 
 export async function evaluateAsync(expression) {
   return evaluate(expression, { awaitPromise: true });
+}
+
+/**
+ * Run an evaluate() under the process-wide write mutex.
+ *
+ * Use this for any handler whose JS expression MUTATES chart/page state
+ * — chart_set_*, indicator add/remove, draw_*, alert_create/delete,
+ * pane_set_*, tab_*, pine_set_source, pine_smart_compile, replay_*,
+ * batch_run when it contains write subtasks.
+ *
+ * Read-only handlers stay on evaluate() — no contention, no overhead.
+ *
+ * @param {string} expression - JS expression to evaluate on the page.
+ * @param {object} [opts] - Same options as evaluate().
+ * @returns {Promise<*>} - Same return shape as evaluate().
+ */
+export async function evaluateWrite(expression, opts = {}) {
+  return writeMutex.runExclusive(() => evaluate(expression, opts));
+}
+
+/**
+ * Run a multi-step write sequence (multiple evaluate() calls) atomically
+ * under the write mutex. Use this when a single logical operation issues
+ * 2+ JS evaluations that must NOT interleave with another writer's
+ * sequence — e.g. chart_manage_indicator captures the before-snapshot,
+ * runs the add/remove, then captures the after-snapshot.
+ *
+ * The callback receives the unlocked evaluate() so it can run multiple
+ * reads/writes inside the critical section without re-locking.
+ *
+ * @param {function((string, object?) => Promise<*>): Promise<*>} fn
+ *   Async callback that receives evaluate() and returns its result.
+ * @returns {Promise<*>}
+ */
+export async function withWriteLock(fn) {
+  return writeMutex.runExclusive(() => fn(evaluate));
 }
 
 export async function disconnect() {

--- a/src/core/alerts.js
+++ b/src/core/alerts.js
@@ -1,10 +1,15 @@
 /**
  * Core alert logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateWrite, evaluateAsync, withWriteLock, getClient } from '../connection.js';
 
 export async function create({ condition, price, message }) {
-  const opened = await evaluate(`
+  // Multi-step UI sequence — open dialog → set price → set message →
+  // submit. Lock the whole thing so a concurrent create can't interleave
+  // and corrupt the form state. (Note: also holds the lock during the
+  // CDP keystroke dispatch in the fallback path.)
+  return withWriteLock(async (evalInside) => {
+    const opened = await evalInside(`
     (function() {
       var btn = document.querySelector('[aria-label="Create Alert"]')
         || document.querySelector('[data-name="alerts"]');
@@ -21,7 +26,7 @@ export async function create({ condition, price, message }) {
 
   await new Promise(r => setTimeout(r, 1000));
 
-  const priceSet = await evaluate(`
+  const priceSet = await evalInside(`
     (function() {
       var inputs = document.querySelectorAll('[class*="alert"] input[type="text"], [class*="alert"] input[type="number"]');
       for (var i = 0; i < inputs.length; i++) {
@@ -45,7 +50,7 @@ export async function create({ condition, price, message }) {
   `);
 
   if (message) {
-    await evaluate(`
+    await evalInside(`
       (function() {
         var textarea = document.querySelector('[class*="alert"] textarea')
           || document.querySelector('textarea[placeholder*="message"]');
@@ -59,7 +64,7 @@ export async function create({ condition, price, message }) {
   }
 
   await new Promise(r => setTimeout(r, 500));
-  const created = await evaluate(`
+  const created = await evalInside(`
     (function() {
       var btns = document.querySelectorAll('button[data-name="submit"], button');
       for (var i = 0; i < btns.length; i++) {
@@ -70,6 +75,7 @@ export async function create({ condition, price, message }) {
   `);
 
   return { success: !!created, price, condition, message: message || '(none)', price_set: !!priceSet, source: 'dom_fallback' };
+  });  // end withWriteLock
 }
 
 export async function list() {
@@ -105,7 +111,7 @@ export async function list() {
 
 export async function deleteAlerts({ delete_all }) {
   if (delete_all) {
-    const result = await evaluate(`
+    const result = await evaluateWrite(`
       (function() {
         var alertBtn = document.querySelector('[data-name="alerts"]');
         if (alertBtn) alertBtn.click();

--- a/src/core/batch.js
+++ b/src/core/batch.js
@@ -1,7 +1,11 @@
 /**
  * Core batch execution logic.
  */
-import { evaluate, evaluateAsync, getClient, getChartApi, getChartCollection } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock, getClient, getChartApi, getChartCollection } from '../connection.js';
+
+async function evaluateAsyncWrite(expression) {
+  return evaluateWrite(expression, { awaitPromise: true });
+}
 import { waitForChartReady } from '../wait.js';
 import { writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
@@ -23,13 +27,23 @@ export async function batchRun({ symbols, timeframes, action, delay_ms, ohlcv_co
     for (const tf of tfs) {
       const combo = { symbol, timeframe: tf };
       try {
-        if (colPath) await evaluate(`${colPath}.setSymbol('${symbol}')`);
-        else if (apiPath) await evaluate(`${apiPath}.setSymbol('${symbol}')`);
+        // Lock the symbol/tf switch per iteration so a concurrent
+        // batchRun (or any other writer) can't change symbol mid-flight
+        // and corrupt the action data. The action itself runs OUTSIDE
+        // the lock — actions like screenshot or get_ohlcv are reads
+        // once the chart is positioned. (Strategy-results panel scrape
+        // is also a read.) This per-iteration locking lets other
+        // writers interleave between iterations rather than holding
+        // them off for the full batch.
+        await withWriteLock(async (evalInside) => {
+          if (colPath) await evalInside(`${colPath}.setSymbol('${symbol}')`);
+          else if (apiPath) await evalInside(`${apiPath}.setSymbol('${symbol}')`);
 
-        if (tf) {
-          if (colPath) await evaluate(`${colPath}.setResolution('${tf}')`);
-          else if (apiPath) await evaluate(`${apiPath}.setResolution('${tf}')`);
-        }
+          if (tf) {
+            if (colPath) await evalInside(`${colPath}.setResolution('${tf}')`);
+            else if (apiPath) await evalInside(`${apiPath}.setResolution('${tf}')`);
+          }
+        });
 
         await waitForChartReady(symbol);
         await new Promise(r => setTimeout(r, delay));

--- a/src/core/chart.js
+++ b/src/core/chart.js
@@ -1,8 +1,15 @@
 /**
  * Core chart control logic.
  */
-import { evaluate, evaluateAsync } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock } from '../connection.js';
 import { waitForChartReady } from '../wait.js';
+
+// Local helper: evaluateAsync under the write mutex. setSymbol is the
+// only write that awaits a promise inside the evaluation; everything
+// else uses evaluateWrite() / withWriteLock() directly.
+async function evaluateAsyncWrite(expression) {
+  return evaluateWrite(expression, { awaitPromise: true });
+}
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
@@ -29,7 +36,7 @@ export async function getState() {
 }
 
 export async function setSymbol({ symbol }) {
-  await evaluateAsync(`
+  await evaluateAsyncWrite(`
     (function() {
       var chart = ${CHART_API};
       return new Promise(function(resolve) {
@@ -43,7 +50,7 @@ export async function setSymbol({ symbol }) {
 }
 
 export async function setTimeframe({ timeframe }) {
-  await evaluate(`
+  await evaluateWrite(`
     (function() {
       var chart = ${CHART_API};
       chart.setResolution('${timeframe.replace(/'/g, "\\'")}', {});
@@ -63,7 +70,7 @@ export async function setType({ chart_type }) {
   if (isNaN(typeNum)) {
     throw new Error(`Unknown chart type: ${chart_type}. Use a name (Candles, Line, etc.) or number (0-9).`);
   }
-  await evaluate(`
+  await evaluateWrite(`
     (function() {
       var chart = ${CHART_API};
       chart.setChartType(${typeNum});
@@ -75,31 +82,36 @@ export async function setType({ chart_type }) {
 export async function manageIndicator({ action, indicator, entity_id, inputs: inputsRaw }) {
   const inputs = inputsRaw ? (typeof inputsRaw === 'string' ? JSON.parse(inputsRaw) : inputsRaw) : undefined;
 
-  if (action === 'add') {
-    const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
-    const before = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
-    await evaluate(`
-      (function() {
-        var chart = ${CHART_API};
-        chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
-      })()
-    `);
-    await new Promise(r => setTimeout(r, 1500));
-    const after = await evaluate(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
-    const newIds = (after || []).filter(id => !(before || []).includes(id));
-    return { success: newIds.length > 0, action: 'add', indicator, entity_id: newIds[0] || null, new_study_count: newIds.length };
-  } else if (action === 'remove') {
-    if (!entity_id) throw new Error('entity_id required for remove action. Use chart_get_state to find study IDs.');
-    await evaluate(`
-      (function() {
-        var chart = ${CHART_API};
-        chart.removeEntity('${entity_id.replace(/'/g, "\\'")}');
-      })()
-    `);
-    return { success: true, action: 'remove', entity_id };
-  } else {
-    throw new Error('action must be "add" or "remove"');
-  }
+  // Multi-step write — before/after snapshot of study IDs around the
+  // mutation must be inside the same critical section, otherwise a
+  // concurrent add would corrupt the newIds diff.
+  return withWriteLock(async (evalInside) => {
+    if (action === 'add') {
+      const inputArr = inputs ? Object.entries(inputs).map(([k, v]) => ({ id: k, value: v })) : [];
+      const before = await evalInside(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
+      await evalInside(`
+        (function() {
+          var chart = ${CHART_API};
+          chart.createStudy('${indicator.replace(/'/g, "\\'")}', false, false, ${JSON.stringify(inputArr)});
+        })()
+      `);
+      await new Promise(r => setTimeout(r, 1500));
+      const after = await evalInside(`${CHART_API}.getAllStudies().map(function(s) { return s.id; })`);
+      const newIds = (after || []).filter(id => !(before || []).includes(id));
+      return { success: newIds.length > 0, action: 'add', indicator, entity_id: newIds[0] || null, new_study_count: newIds.length };
+    } else if (action === 'remove') {
+      if (!entity_id) throw new Error('entity_id required for remove action. Use chart_get_state to find study IDs.');
+      await evalInside(`
+        (function() {
+          var chart = ${CHART_API};
+          chart.removeEntity('${entity_id.replace(/'/g, "\\'")}');
+        })()
+      `);
+      return { success: true, action: 'remove', entity_id };
+    } else {
+      throw new Error('action must be "add" or "remove"');
+    }
+  });
 }
 
 export async function getVisibleRange() {
@@ -113,32 +125,37 @@ export async function getVisibleRange() {
 }
 
 export async function setVisibleRange({ from, to }) {
-  await evaluate(`
-    (function() {
-      var chart = ${CHART_API};
-      var m = chart._chartWidget.model();
-      var ts = m.timeScale();
-      var bars = m.mainSeries().bars();
-      var startIdx = bars.firstIndex();
-      var endIdx = bars.lastIndex();
-      var fromIdx = startIdx, toIdx = endIdx;
-      for (var i = startIdx; i <= endIdx; i++) {
-        var v = bars.valueAt(i);
-        if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
-        if (v && v[0] <= ${to}) toIdx = i;
-      }
-      ts.zoomToBarsRange(fromIdx, toIdx);
-    })()
-  `);
-  await new Promise(r => setTimeout(r, 500));
-  const actual = await evaluate(`
-    (function() {
-      var chart = ${CHART_API};
-      try { var r = chart.getVisibleRange(); return { from: r.from || 0, to: r.to || 0 }; }
-      catch(e) { return { from: 0, to: 0, error: e.message }; }
-    })()
-  `);
-  return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
+  // Multi-step: write the zoom, then read back the actual range for the
+  // response. Both inside the mutex so a concurrent setVisibleRange
+  // can't change the viewport between our write and our read-back.
+  return withWriteLock(async (evalInside) => {
+    await evalInside(`
+      (function() {
+        var chart = ${CHART_API};
+        var m = chart._chartWidget.model();
+        var ts = m.timeScale();
+        var bars = m.mainSeries().bars();
+        var startIdx = bars.firstIndex();
+        var endIdx = bars.lastIndex();
+        var fromIdx = startIdx, toIdx = endIdx;
+        for (var i = startIdx; i <= endIdx; i++) {
+          var v = bars.valueAt(i);
+          if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
+          if (v && v[0] <= ${to}) toIdx = i;
+        }
+        ts.zoomToBarsRange(fromIdx, toIdx);
+      })()
+    `);
+    await new Promise(r => setTimeout(r, 500));
+    const actual = await evalInside(`
+      (function() {
+        var chart = ${CHART_API};
+        try { var r = chart.getVisibleRange(); return { from: r.from || 0, to: r.to || 0 }; }
+        catch(e) { return { from: 0, to: 0, error: e.message }; }
+      })()
+    `);
+    return { success: true, requested: { from, to }, actual: actual || { from: 0, to: 0 } };
+  });
 }
 
 export async function scrollToDate({ date }) {
@@ -147,37 +164,41 @@ export async function scrollToDate({ date }) {
   else timestamp = Math.floor(new Date(date).getTime() / 1000);
   if (isNaN(timestamp)) throw new Error(`Could not parse date: ${date}. Use ISO format (2024-01-15) or unix timestamp.`);
 
-  const resolution = await evaluate(`${CHART_API}.resolution()`);
-  let secsPerBar = 60;
-  const res = String(resolution);
-  if (res === 'D' || res === '1D') secsPerBar = 86400;
-  else if (res === 'W' || res === '1W') secsPerBar = 604800;
-  else if (res === 'M' || res === '1M') secsPerBar = 2592000;
-  else { const mins = parseInt(res, 10); if (!isNaN(mins)) secsPerBar = mins * 60; }
+  // Read-then-write sequence: resolution read must see the same
+  // resolution the zoom write operates on. Lock both.
+  return withWriteLock(async (evalInside) => {
+    const resolution = await evalInside(`${CHART_API}.resolution()`);
+    let secsPerBar = 60;
+    const res = String(resolution);
+    if (res === 'D' || res === '1D') secsPerBar = 86400;
+    else if (res === 'W' || res === '1W') secsPerBar = 604800;
+    else if (res === 'M' || res === '1M') secsPerBar = 2592000;
+    else { const mins = parseInt(res, 10); if (!isNaN(mins)) secsPerBar = mins * 60; }
 
-  const halfWindow = 25 * secsPerBar;
-  const from = timestamp - halfWindow;
-  const to = timestamp + halfWindow;
+    const halfWindow = 25 * secsPerBar;
+    const from = timestamp - halfWindow;
+    const to = timestamp + halfWindow;
 
-  await evaluate(`
-    (function() {
-      var chart = ${CHART_API};
-      var m = chart._chartWidget.model();
-      var ts = m.timeScale();
-      var bars = m.mainSeries().bars();
-      var startIdx = bars.firstIndex();
-      var endIdx = bars.lastIndex();
-      var fromIdx = startIdx, toIdx = endIdx;
-      for (var i = startIdx; i <= endIdx; i++) {
-        var v = bars.valueAt(i);
-        if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
-        if (v && v[0] <= ${to}) toIdx = i;
-      }
-      ts.zoomToBarsRange(fromIdx, toIdx);
-    })()
-  `);
-  await new Promise(r => setTimeout(r, 500));
-  return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
+    await evalInside(`
+      (function() {
+        var chart = ${CHART_API};
+        var m = chart._chartWidget.model();
+        var ts = m.timeScale();
+        var bars = m.mainSeries().bars();
+        var startIdx = bars.firstIndex();
+        var endIdx = bars.lastIndex();
+        var fromIdx = startIdx, toIdx = endIdx;
+        for (var i = startIdx; i <= endIdx; i++) {
+          var v = bars.valueAt(i);
+          if (v && v[0] >= ${from} && fromIdx === startIdx) fromIdx = i;
+          if (v && v[0] <= ${to}) toIdx = i;
+        }
+        ts.zoomToBarsRange(fromIdx, toIdx);
+      })()
+    `);
+    await new Promise(r => setTimeout(r, 500));
+    return { success: true, date, centered_on: timestamp, resolution, window: { from, to } };
+  });
 }
 
 export async function symbolInfo() {

--- a/src/core/drawing.js
+++ b/src/core/drawing.js
@@ -1,7 +1,7 @@
 /**
  * Core drawing logic.
  */
-import { evaluate, getChartApi } from '../connection.js';
+import { evaluate, evaluateWrite, withWriteLock, getChartApi } from '../connection.js';
 
 export async function drawShape({ shape, point, point2, overrides: overridesRaw, text }) {
   const overrides = overridesRaw ? (typeof overridesRaw === 'string' ? JSON.parse(overridesRaw) : overridesRaw) : {};
@@ -9,29 +9,32 @@ export async function drawShape({ shape, point, point2, overrides: overridesRaw,
   const overridesStr = JSON.stringify(overrides || {});
   const textStr = text ? JSON.stringify(text) : '""';
 
-  const before = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
+  // Multi-step write — before/after snapshot must be in the same
+  // critical section so concurrent draws don't corrupt the newId diff.
+  return withWriteLock(async (evalInside) => {
+    const before = await evalInside(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
 
-  if (point2) {
-    await evaluate(`
-      ${apiPath}.createMultipointShape(
-        [{ time: ${point.time}, price: ${point.price} }, { time: ${point2.time}, price: ${point2.price} }],
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
-      )
-    `);
-  } else {
-    await evaluate(`
-      ${apiPath}.createShape(
-        { time: ${point.time}, price: ${point.price} },
-        { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
-      )
-    `);
-  }
+    if (point2) {
+      await evalInside(`
+        ${apiPath}.createMultipointShape(
+          [{ time: ${point.time}, price: ${point.price} }, { time: ${point2.time}, price: ${point2.price} }],
+          { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        )
+      `);
+    } else {
+      await evalInside(`
+        ${apiPath}.createShape(
+          { time: ${point.time}, price: ${point.price} },
+          { shape: '${shape}', overrides: ${overridesStr}, text: ${textStr} }
+        )
+      `);
+    }
 
-  await new Promise(r => setTimeout(r, 200));
-  const after = await evaluate(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
-  const newId = (after || []).find(id => !(before || []).includes(id)) || null;
-  const result = { entity_id: newId };
-  return { success: true, shape, entity_id: result?.entity_id };
+    await new Promise(r => setTimeout(r, 200));
+    const after = await evalInside(`${apiPath}.getAllShapes().map(function(s) { return s.id; })`);
+    const newId = (after || []).find(id => !(before || []).includes(id)) || null;
+    return { success: true, shape, entity_id: newId };
+  });
 }
 
 export async function listDrawings() {
@@ -77,7 +80,7 @@ export async function getProperties({ entity_id }) {
 
 export async function removeOne({ entity_id }) {
   const apiPath = await getChartApi();
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var api = ${apiPath};
       var eid = '${entity_id}';
@@ -98,6 +101,6 @@ export async function removeOne({ entity_id }) {
 
 export async function clearAll() {
   const apiPath = await getChartApi();
-  await evaluate(`${apiPath}.removeAllShapes()`);
+  await evaluateWrite(`${apiPath}.removeAllShapes()`);
   return { success: true, action: 'all_shapes_removed' };
 }

--- a/src/core/indicators.js
+++ b/src/core/indicators.js
@@ -1,7 +1,7 @@
 /**
  * Core indicator settings logic.
  */
-import { evaluate } from '../connection.js';
+import { evaluateWrite } from '../connection.js';
 
 const CHART_API = 'window.TradingViewApi._activeChartWidgetWV.value()';
 
@@ -15,7 +15,7 @@ export async function setInputs({ entity_id, inputs: inputsRaw }) {
   const escapedId = entity_id.replace(/'/g, "\\'");
   const inputsJson = JSON.stringify(inputs);
 
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var chart = ${CHART_API};
       var study = chart.getStudyById('${escapedId}');
@@ -43,7 +43,7 @@ export async function toggleVisibility({ entity_id, visible }) {
   if (typeof visible !== 'boolean') throw new Error('visible must be a boolean (true or false)');
 
   const escapedId = entity_id.replace(/'/g, "\\'");
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var chart = ${CHART_API};
       var study = chart.getStudyById('${escapedId}');

--- a/src/core/pane.js
+++ b/src/core/pane.js
@@ -2,7 +2,12 @@
  * Core pane/layout management logic.
  * Controls multi-chart layouts (split panes) in TradingView.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock, getClient } from '../connection.js';
+
+// Local helper: evaluateAsync under the write mutex.
+async function evaluateAsyncWrite(expression) {
+  return evaluateWrite(expression, { awaitPromise: true });
+}
 
 const CWC = 'window.TradingViewApi._chartWidgetCollection';
 
@@ -96,7 +101,7 @@ export async function setLayout({ layout }) {
     throw new Error(`Unknown layout "${layout}". Available layouts:\n${available}`);
   }
 
-  await evaluateAsync(`${CWC}.setLayout('${resolved}')`);
+  await evaluateAsyncWrite(`${CWC}.setLayout('${resolved}')`);
   await new Promise(r => setTimeout(r, 500));
 
   const state = await list();
@@ -114,7 +119,7 @@ export async function setLayout({ layout }) {
  */
 export async function focus({ index }) {
   const idx = Number(index);
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var cwc = ${CWC};
       var all = cwc.getAll();
@@ -138,20 +143,33 @@ export async function setSymbol({ index, symbol }) {
   const idx = Number(index);
   const escaped = symbol.replace(/'/g, "\\'");
 
-  // Focus the target pane first
-  await focus({ index: idx });
-  await new Promise(r => setTimeout(r, 300));
-
-  // Now set symbol on the now-active chart
-  await evaluateAsync(`
-    (function() {
-      var chart = window.TradingViewApi._activeChartWidgetWV.value();
-      return new Promise(function(resolve) {
-        chart.setSymbol('${escaped}', {});
-        setTimeout(resolve, 500);
-      });
-    })()
-  `);
-
-  return { success: true, index: idx, symbol };
+  // Multi-step: focus pane → wait → set symbol on active chart. Lock
+  // the whole thing so a concurrent setSymbol on a different pane index
+  // can't steal focus between our focus() and setSymbol() calls. focus()
+  // itself already locks via evaluateWrite, so we use withWriteLock here
+  // and call the inner CDP eval directly to avoid double-locking.
+  return withWriteLock(async (evalInside) => {
+    // Inline focus logic (avoid recursive lock from focus())
+    await evalInside(`
+      (function() {
+        var cwc = ${CWC};
+        var all = cwc.getAll();
+        if (${idx} >= all.length) throw new Error('Pane index ' + ${idx} + ' out of range (have ' + all.length + ' panes)');
+        var chart = all[${idx}];
+        if (chart._mainDiv) chart._mainDiv.click();
+        return true;
+      })()
+    `);
+    await new Promise(r => setTimeout(r, 300));
+    await evalInside(`
+      (function() {
+        var chart = window.TradingViewApi._activeChartWidgetWV.value();
+        return new Promise(function(resolve) {
+          chart.setSymbol('${escaped}', {});
+          setTimeout(resolve, 500);
+        });
+      })()
+    `, { awaitPromise: true });
+    return { success: true, index: idx, symbol };
+  });
 }

--- a/src/core/pine.js
+++ b/src/core/pine.js
@@ -3,7 +3,11 @@
  * All functions accept plain options objects and return plain JS objects.
  * They throw on error (callers catch and format).
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock, getClient } from '../connection.js';
+
+async function evaluateAsyncWrite(expression) {
+  return evaluateWrite(expression, { awaitPromise: true });
+}
 
 // ── Monaco finder (injected into TV page) ──
 const FIND_MONACO = `
@@ -268,7 +272,7 @@ export async function setSource({ source }) {
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
   const escaped = JSON.stringify(source);
-  const set = await evaluate(`
+  const set = await evaluateWrite(`
     (function() {
       var m = ${FIND_MONACO};
       if (!m) return false;
@@ -285,7 +289,7 @@ export async function compile() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const clicked = await evaluate(`
+  const clicked = await evaluateWrite(`
     (function() {
       var btns = document.querySelectorAll('button');
       var fallback = null;
@@ -348,13 +352,16 @@ export async function save() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
+  // Multi-step write: Ctrl+S keystrokes + dialog handling. Lock the
+  // whole thing so a concurrent save can't steal the dialog focus.
+  return withWriteLock(async (evalInside) => {
   const c = await getClient();
   await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: 2, key: 's', code: 'KeyS', windowsVirtualKeyCode: 83 });
   await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 's', code: 'KeyS' });
   await new Promise(r => setTimeout(r, 800));
 
   // Handle "Save Script" name dialog that appears for new/unsaved scripts
-  const dialogHandled = await evaluate(`
+  const dialogHandled = await evalInside(`
     (function() {
       var saveBtn = null;
       var btns = document.querySelectorAll('button');
@@ -374,6 +381,7 @@ export async function save() {
   if (dialogHandled) await new Promise(r => setTimeout(r, 500));
 
   return { success: true, action: dialogHandled ? 'saved_with_dialog' : 'Ctrl+S_dispatched' };
+  });  // end withWriteLock
 }
 
 export async function getConsole() {
@@ -430,7 +438,11 @@ export async function smartCompile() {
   const editorReady = await ensurePineEditorOpen();
   if (!editorReady) throw new Error('Could not open Pine Editor.');
 
-  const studiesBefore = await evaluate(`
+  // Multi-step write: before snapshot → click compile → wait → after
+  // snapshot + errors. Lock the whole sequence so concurrent compiles
+  // can't race on the studies-count diff.
+  return withWriteLock(async (evalInside) => {
+  const studiesBefore = await evalInside(`
     (function() {
       try {
         var chart = window.TradingViewApi._activeChartWidgetWV.value();
@@ -440,7 +452,7 @@ export async function smartCompile() {
     })()
   `);
 
-  const buttonClicked = await evaluate(`
+  const buttonClicked = await evalInside(`
     (function() {
       var btns = document.querySelectorAll('button');
       var addBtn = null;
@@ -471,7 +483,7 @@ export async function smartCompile() {
 
   await new Promise(r => setTimeout(r, 2500));
 
-  const errors = await evaluate(`
+  const errors = await evalInside(`
     (function() {
       var m = ${FIND_MONACO};
       if (!m) return [];
@@ -484,7 +496,7 @@ export async function smartCompile() {
     })()
   `);
 
-  const studiesAfter = await evaluate(`
+  const studiesAfter = await evalInside(`
     (function() {
       try {
         var chart = window.TradingViewApi._activeChartWidgetWV.value();
@@ -503,6 +515,7 @@ export async function smartCompile() {
     errors: errors || [],
     study_added: studyAdded,
   };
+  });  // end withWriteLock
 }
 
 export async function newScript({ type }) {
@@ -520,7 +533,7 @@ export async function newScript({ type }) {
 
   // Simply set the source to a new template — this is the most reliable approach
   const escaped = JSON.stringify(template);
-  const set = await evaluate(`
+  const set = await evaluateWrite(`
     (function() {
       var m = ${FIND_MONACO};
       if (!m) return false;
@@ -540,7 +553,7 @@ export async function openScript({ name }) {
 
   const escapedName = JSON.stringify(name.toLowerCase());
 
-  const result = await evaluateAsync(`
+  const result = await evaluateAsyncWrite(`
     (function() {
       var target = ${escapedName};
       return fetch('https://pine-facade.tradingview.com/pine-facade/list/?filter=saved', { credentials: 'include' })

--- a/src/core/replay.js
+++ b/src/core/replay.js
@@ -1,94 +1,107 @@
 /**
  * Core replay mode logic.
  */
-import { evaluate, getReplayApi } from '../connection.js';
+import { evaluate, withWriteLock, getReplayApi } from '../connection.js';
 
 function wv(path) {
   return `(function(){ var v = ${path}; return (v && typeof v === 'object' && typeof v.value === 'function') ? v.value() : v; })()`;
 }
 
+// All replay control functions hold the write mutex for their entire
+// sequence — replay state is a single-machine state machine, and
+// interleaving two clients' start/step/autoplay/stop/trade calls would
+// corrupt the playback session (and possibly the chart itself, per the
+// "Data point unavailable" toast handling in start()).
+
 export async function start({ date } = {}) {
   const rp = await getReplayApi();
-  const available = await evaluate(wv(`${rp}.isReplayAvailable()`));
-  if (!available) throw new Error('Replay is not available for the current symbol/timeframe');
+  return withWriteLock(async (evalInside) => {
+    const available = await evalInside(wv(`${rp}.isReplayAvailable()`));
+    if (!available) throw new Error('Replay is not available for the current symbol/timeframe');
 
-  await evaluate(`${rp}.showReplayToolbar()`);
-  await new Promise(r => setTimeout(r, 500));
+    await evalInside(`${rp}.showReplayToolbar()`);
+    await new Promise(r => setTimeout(r, 500));
 
-  if (date) await evaluate(`${rp}.selectDate(new Date('${date}'))`);
-  else await evaluate(`${rp}.selectFirstAvailableDate()`);
-  await new Promise(r => setTimeout(r, 1000));
+    if (date) await evalInside(`${rp}.selectDate(new Date('${date}'))`);
+    else await evalInside(`${rp}.selectFirstAvailableDate()`);
+    await new Promise(r => setTimeout(r, 1000));
 
-  // Check for "Data point unavailable" toast which corrupts the chart
-  const toast = await evaluate(`
-    (function() {
-      var toasts = document.querySelectorAll('[class*="toast"], [class*="notification"], [class*="banner"]');
-      for (var i = 0; i < toasts.length; i++) {
-        var text = toasts[i].textContent || '';
-        if (/data point unavailable|not available for playback/i.test(text)) return text.trim().substring(0, 200);
-      }
-      return null;
-    })()
-  `);
+    const toast = await evalInside(`
+      (function() {
+        var toasts = document.querySelectorAll('[class*="toast"], [class*="notification"], [class*="banner"]');
+        for (var i = 0; i < toasts.length; i++) {
+          var text = toasts[i].textContent || '';
+          if (/data point unavailable|not available for playback/i.test(text)) return text.trim().substring(0, 200);
+        }
+        return null;
+      })()
+    `);
 
-  if (toast) {
-    // Stop replay to recover chart
-    try { await evaluate(`${rp}.stopReplay()`); } catch {}
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
-    throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
-  }
+    if (toast) {
+      try { await evalInside(`${rp}.stopReplay()`); } catch {}
+      try { await evalInside(`${rp}.hideReplayToolbar()`); } catch {}
+      throw new Error(`Replay date unavailable: "${toast}". The requested date has no data for this timeframe. Try a more recent date or switch to a higher timeframe (e.g., Daily).`);
+    }
 
-  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
-  const currentDate = await evaluate(wv(`${rp}.currentDate()`));
-  return { success: true, replay_started: !!started, date: date || '(first available)', current_date: currentDate };
+    const started = await evalInside(wv(`${rp}.isReplayStarted()`));
+    const currentDate = await evalInside(wv(`${rp}.currentDate()`));
+    return { success: true, replay_started: !!started, date: date || '(first available)', current_date: currentDate };
+  });
 }
 
 export async function step() {
   const rp = await getReplayApi();
-  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
-  if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  await evaluate(`${rp}.doStep()`);
-  const currentDate = await evaluate(wv(`${rp}.currentDate()`));
-  return { success: true, action: 'step', current_date: currentDate };
+  return withWriteLock(async (evalInside) => {
+    const started = await evalInside(wv(`${rp}.isReplayStarted()`));
+    if (!started) throw new Error('Replay is not started. Use replay_start first.');
+    await evalInside(`${rp}.doStep()`);
+    const currentDate = await evalInside(wv(`${rp}.currentDate()`));
+    return { success: true, action: 'step', current_date: currentDate };
+  });
 }
 
 export async function autoplay({ speed } = {}) {
   const rp = await getReplayApi();
-  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
-  if (!started) throw new Error('Replay is not started. Use replay_start first.');
-  if (speed > 0) await evaluate(`${rp}.changeAutoplayDelay(${speed})`);
-  await evaluate(`${rp}.toggleAutoplay()`);
-  const isAutoplay = await evaluate(wv(`${rp}.isAutoplayStarted()`));
-  const currentDelay = await evaluate(wv(`${rp}.autoplayDelay()`));
-  return { success: true, autoplay_active: !!isAutoplay, delay_ms: currentDelay };
+  return withWriteLock(async (evalInside) => {
+    const started = await evalInside(wv(`${rp}.isReplayStarted()`));
+    if (!started) throw new Error('Replay is not started. Use replay_start first.');
+    if (speed > 0) await evalInside(`${rp}.changeAutoplayDelay(${speed})`);
+    await evalInside(`${rp}.toggleAutoplay()`);
+    const isAutoplay = await evalInside(wv(`${rp}.isAutoplayStarted()`));
+    const currentDelay = await evalInside(wv(`${rp}.autoplayDelay()`));
+    return { success: true, autoplay_active: !!isAutoplay, delay_ms: currentDelay };
+  });
 }
 
 export async function stop() {
   const rp = await getReplayApi();
-  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
-  if (!started) {
-    // Try to hide toolbar even if not started
-    try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
-    return { success: true, action: 'already_stopped' };
-  }
-  await evaluate(`${rp}.stopReplay()`);
-  try { await evaluate(`${rp}.hideReplayToolbar()`); } catch {}
-  return { success: true, action: 'replay_stopped' };
+  return withWriteLock(async (evalInside) => {
+    const started = await evalInside(wv(`${rp}.isReplayStarted()`));
+    if (!started) {
+      try { await evalInside(`${rp}.hideReplayToolbar()`); } catch {}
+      return { success: true, action: 'already_stopped' };
+    }
+    await evalInside(`${rp}.stopReplay()`);
+    try { await evalInside(`${rp}.hideReplayToolbar()`); } catch {}
+    return { success: true, action: 'replay_stopped' };
+  });
 }
 
 export async function trade({ action }) {
   const rp = await getReplayApi();
-  const started = await evaluate(wv(`${rp}.isReplayStarted()`));
-  if (!started) throw new Error('Replay is not started. Use replay_start first.');
+  return withWriteLock(async (evalInside) => {
+    const started = await evalInside(wv(`${rp}.isReplayStarted()`));
+    if (!started) throw new Error('Replay is not started. Use replay_start first.');
 
-  if (action === 'buy') await evaluate(`${rp}.buy()`);
-  else if (action === 'sell') await evaluate(`${rp}.sell()`);
-  else if (action === 'close') await evaluate(`${rp}.closePosition()`);
-  else throw new Error('Invalid action. Use: buy, sell, or close');
+    if (action === 'buy') await evalInside(`${rp}.buy()`);
+    else if (action === 'sell') await evalInside(`${rp}.sell()`);
+    else if (action === 'close') await evalInside(`${rp}.closePosition()`);
+    else throw new Error('Invalid action. Use: buy, sell, or close');
 
-  const position = await evaluate(wv(`${rp}.position()`));
-  const pnl = await evaluate(wv(`${rp}.realizedPL()`));
-  return { success: true, action, position, realized_pnl: pnl };
+    const position = await evalInside(wv(`${rp}.position()`));
+    const pnl = await evalInside(wv(`${rp}.realizedPL()`));
+    return { success: true, action, position, realized_pnl: pnl };
+  });
 }
 
 export async function status() {

--- a/src/core/ui.js
+++ b/src/core/ui.js
@@ -1,11 +1,15 @@
 /**
  * Core UI automation logic.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock, getClient } from '../connection.js';
+
+async function evaluateAsyncWrite(expression) {
+  return evaluateWrite(expression, { awaitPromise: true });
+}
 
 export async function click({ by, value }) {
   const escaped = JSON.stringify(value);
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var by = ${JSON.stringify(by)};
       var value = ${escaped};
@@ -32,7 +36,7 @@ export async function openPanel({ panel, action }) {
   const isBottomPanel = panel === 'pine-editor' || panel === 'strategy-tester';
   if (isBottomPanel) {
     const widgetName = panel === 'pine-editor' ? 'pine-editor' : 'backtesting';
-    const result = await evaluate(`
+    const result = await evaluateWrite(`
       (function() {
         var bwb = window.TradingView && window.TradingView.bottomWidgetBar;
         if (!bwb) return { error: 'bottomWidgetBar not available' };
@@ -64,7 +68,7 @@ export async function openPanel({ panel, action }) {
       'trading': { dataName: 'trading-button', ariaLabel: 'Trading Panel' },
     };
     const sel = selectorMap[panel];
-    const result = await evaluate(`
+    const result = await evaluateWrite(`
       (function() {
         var dataName = ${JSON.stringify(sel.dataName)};
         var ariaLabel = ${JSON.stringify(sel.ariaLabel)};
@@ -89,7 +93,7 @@ export async function openPanel({ panel, action }) {
 }
 
 export async function fullscreen() {
-  const result = await evaluate(`
+  const result = await evaluateWrite(`
     (function() {
       var btn = document.querySelector('[data-name="header-toolbar-fullscreen"]');
       if (!btn) return { found: false };
@@ -119,7 +123,11 @@ export async function layoutList() {
 
 export async function layoutSwitch({ name }) {
   const escaped = JSON.stringify(name);
-  const result = await evaluateAsync(`
+  // Layout switch + dialog dismissal is multi-step. Lock the whole
+  // sequence so a concurrent layoutSwitch can't race on the unsaved-
+  // changes dialog.
+  return withWriteLock(async (evalInside) => {
+  const result = await evalInside(`
     new Promise(function(resolve) {
       try {
         var target = ${escaped};
@@ -137,12 +145,12 @@ export async function layoutSwitch({ name }) {
         setTimeout(function() { resolve({success: false, error: 'getSavedCharts timed out', source: 'internal_api'}); }, 5000);
       } catch(e) { resolve({success: false, error: e.message, source: 'internal_api'}); }
     })
-  `);
+  `, { awaitPromise: true });
   if (!result?.success) throw new Error(result?.error || 'Unknown error switching layout');
 
   // Handle "unsaved changes" confirmation dialog
   await new Promise(r => setTimeout(r, 500));
-  const dismissed = await evaluate(`
+  const dismissed = await evalInside(`
     (function() {
       var btns = document.querySelectorAll('button');
       for (var i = 0; i < btns.length; i++) {
@@ -158,9 +166,11 @@ export async function layoutSwitch({ name }) {
 
   if (dismissed) await new Promise(r => setTimeout(r, 1000));
   return { success: true, layout: result.name || name, layout_id: result.id, source: result.source, action: 'switched', unsaved_dialog_dismissed: dismissed };
+  });  // end withWriteLock
 }
 
 export async function keyboard({ key, modifiers }) {
+  return withWriteLock(async () => {
   const c = await getClient();
   let mod = 0;
   if (modifiers) {
@@ -182,16 +192,20 @@ export async function keyboard({ key, modifiers }) {
   await c.Input.dispatchKeyEvent({ type: 'keyDown', modifiers: mod, key, code: mapped.code, windowsVirtualKeyCode: mapped.vk });
   await c.Input.dispatchKeyEvent({ type: 'keyUp', key, code: mapped.code });
   return { success: true, key, modifiers: modifiers || [] };
+  });  // end withWriteLock
 }
 
 export async function typeText({ text }) {
+  return withWriteLock(async () => {
   const c = await getClient();
   await c.Input.insertText({ text });
   return { success: true, typed: text.substring(0, 100), length: text.length };
+  });
 }
 
 export async function hover({ by, value }) {
-  const coords = await evaluate(`
+  return withWriteLock(async (evalInside) => {
+  const coords = await evalInside(`
     (function() {
       var by = ${JSON.stringify(by)};
       var value = ${JSON.stringify(value)};
@@ -214,12 +228,14 @@ export async function hover({ by, value }) {
   const c = await getClient();
   await c.Input.dispatchMouseEvent({ type: 'mouseMoved', x: coords.x, y: coords.y });
   return { success: true, hovered: { by, value, tag: coords.tag, x: coords.x, y: coords.y } };
+  });  // end withWriteLock
 }
 
 export async function scroll({ direction, amount }) {
+  return withWriteLock(async (evalInside) => {
   const c = await getClient();
   const px = amount || 300;
-  const center = await evaluate(`
+  const center = await evalInside(`
     (function() {
       var el = document.querySelector('[data-name="pane-canvas"]') || document.querySelector('[class*="chart-container"]') || document.querySelector('canvas');
       if (!el) return { x: window.innerWidth / 2, y: window.innerHeight / 2 };
@@ -232,9 +248,11 @@ export async function scroll({ direction, amount }) {
   else if (direction === 'left') deltaX = -px; else if (direction === 'right') deltaX = px;
   await c.Input.dispatchMouseEvent({ type: 'mouseWheel', x: center.x, y: center.y, deltaX, deltaY });
   return { success: true, direction, amount: px };
+  });  // end withWriteLock
 }
 
 export async function mouseClick({ x, y, button, double_click }) {
+  return withWriteLock(async () => {
   const c = await getClient();
   const btn = button === 'right' ? 'right' : button === 'middle' ? 'middle' : 'left';
   const btnNum = btn === 'right' ? 2 : btn === 'middle' ? 1 : 0;
@@ -247,6 +265,7 @@ export async function mouseClick({ x, y, button, double_click }) {
     await c.Input.dispatchMouseEvent({ type: 'mouseReleased', x, y, button: btn });
   }
   return { success: true, x, y, button: btn, double_click: !!double_click };
+  });  // end withWriteLock
 }
 
 export async function findElement({ query, strategy }) {
@@ -288,6 +307,7 @@ export async function findElement({ query, strategy }) {
 }
 
 export async function uiEvaluate({ expression }) {
-  const result = await evaluate(expression);
+  // Arbitrary user-supplied JS — could be a write. Lock for safety.
+  const result = await evaluateWrite(expression);
   return { success: true, result };
 }

--- a/src/core/watchlist.js
+++ b/src/core/watchlist.js
@@ -2,7 +2,7 @@
  * Core watchlist logic.
  * Uses TradingView's internal widget API with DOM fallback.
  */
-import { evaluate, evaluateAsync, getClient } from '../connection.js';
+import { evaluate, evaluateAsync, evaluateWrite, withWriteLock, getClient } from '../connection.js';
 
 export async function get() {
   // Try internal API first — reads from the active watchlist widget
@@ -66,8 +66,11 @@ export async function add({ symbol }) {
   // Use keyboard shortcut to open symbol search in watchlist, type symbol, press Enter
   const c = await getClient();
 
-  // First ensure watchlist panel is open
-  const panelState = await evaluate(`
+  // Multi-step UI sequence: open panel → click add → type → enter →
+  // escape. Lock the whole thing so a concurrent add() doesn't steal
+  // the search input mid-flight.
+  return withWriteLock(async (evalInside) => {
+  const panelState = await evalInside(`
     (function() {
       var btn = document.querySelector('[data-name="base-watchlist-widget-button"]')
         || document.querySelector('[aria-label*="Watchlist"]');
@@ -84,7 +87,7 @@ export async function add({ symbol }) {
   if (panelState?.opened) await new Promise(r => setTimeout(r, 500));
 
   // Click the "Add symbol" button (various selectors)
-  const addClicked = await evaluate(`
+  const addClicked = await evalInside(`
     (function() {
       var selectors = [
         '[data-name="add-symbol-button"]',
@@ -129,4 +132,5 @@ export async function add({ symbol }) {
   await c.Input.dispatchKeyEvent({ type: 'keyUp', key: 'Escape', code: 'Escape' });
 
   return { success: true, symbol, action: 'added' };
+  });  // end withWriteLock
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { withToolName } from "./tracer.js";
 import { registerHealthTools } from "./tools/health.js";
 import { registerChartTools } from "./tools/chart.js";
 import { registerPineTools } from "./tools/pine.js";
@@ -70,6 +71,20 @@ CONTEXT MANAGEMENT:
 - Call chart_get_state ONCE at start, reuse entity IDs`,
   },
 );
+
+// Tracer hook: wrap server.tool so every registered handler runs inside
+// the tracer's AsyncLocalStorage context. When MCP_TRACE_FILE is unset
+// this is a no-op (withToolName returns the handler unchanged) — zero
+// overhead. When tracing is on, every evaluate/evaluateWrite inside the
+// handler picks up the originating MCP tool name automatically.
+const _origTool = server.tool.bind(server);
+server.tool = function (name, ...rest) {
+  const handlerIdx = rest.findIndex((x) => typeof x === "function");
+  if (handlerIdx >= 0) {
+    rest[handlerIdx] = withToolName(name, rest[handlerIdx]);
+  }
+  return _origTool(name, ...rest);
+};
 
 // Register all tool groups
 registerHealthTools(server);

--- a/src/tracer.js
+++ b/src/tracer.js
@@ -1,0 +1,402 @@
+/**
+ * src/tracer.js — optional NDJSON packet tracer for MCP tool dispatch.
+ *
+ * Disabled by default. Activates when MCP_TRACE_FILE is set.
+ *
+ * Captures every evaluate() and evaluateWrite() call with timing and
+ * (when tool-name attribution is wired through registerTool wrappers
+ * in src/server.js) the originating MCP tool name. Each event is one
+ * NDJSON line; the file can be tailed live or parsed offline with jq.
+ *
+ * Design choices:
+ *   - Lazy-init on first call. Zero cost when MCP_TRACE_FILE is unset.
+ *   - Async fire-and-forget appendFile. Buffered: events accumulate in
+ *     memory and flush every MCP_TRACE_BUFFER_MS (default 50ms) or when
+ *     buffer hits 64KB, whichever comes first. Flush on process.beforeExit.
+ *   - Multi-process safe: POSIX write() under PIPE_BUF (4KB on most
+ *     systems) is atomic, and our NDJSON lines stay well under that
+ *     (typical line is 150-300 bytes). Concurrent appends from multiple
+ *     MCP subprocesses interleave at line granularity without tearing.
+ *   - Size-based rotation: when the file exceeds MCP_TRACE_MAX_MB
+ *     (default 50MB), it's renamed to "<path>.1" (replacing any prior
+ *     .1) and a fresh empty file is started. Single-level rotation —
+ *     intentionally minimal complexity. Operators wanting long-term
+ *     retention should pipe through logrotate or similar.
+ *   - Probabilistic sampling: MCP_TRACE_SAMPLE (0.0-1.0, default 1.0)
+ *     drops events. Sampling decision is per-span at start; if a span
+ *     is sampled in, all of its lifecycle events emit (so partial
+ *     spans never appear). Use sample=0.1 in heavy production to cap
+ *     volume.
+ *   - Tool-name attribution via AsyncLocalStorage. server.js wraps each
+ *     registerTool callback in toolContext.run(name, fn) so any
+ *     evaluate/evaluateWrite called inside the handler sees the tool
+ *     name via traceCurrentTool().
+ *
+ * Output schema (NDJSON):
+ *   { ts, pid, seq, kind, id, tool?, excerpt?, dur_ms?, wait_ms?,
+ *     work_ms?, error? }
+ *
+ *   kind ∈ {
+ *     "evaluate.start", "evaluate.end", "evaluate.error",
+ *     "evaluateWrite.queued", "evaluateWrite.acquired",
+ *     "evaluateWrite.released", "evaluateWrite.error"
+ *   }
+ *
+ * Sample analysis (jq):
+ *   # mutex acquire-time distribution
+ *   jq -r 'select(.kind=="evaluateWrite.acquired") | .wait_ms' trace.log
+ *   # outliers
+ *   jq 'select(.kind=="evaluate.end" and .dur_ms > 50)' trace.log
+ *   # call rate per tool
+ *   jq -r 'select(.kind=="evaluate.start") | .tool // "unattributed"' \
+ *     trace.log | sort | uniq -c
+ */
+import { AsyncLocalStorage } from "async_hooks";
+import { appendFile, stat, rename } from "fs/promises";
+
+// ─── Configuration (env-driven, read once on first activation) ────────
+let _config = null;
+function config() {
+  if (_config) return _config;
+  const file = process.env.MCP_TRACE_FILE || null;
+  if (!file) {
+    _config = { enabled: false };
+    return _config;
+  }
+  const maxMB = parseFloat(process.env.MCP_TRACE_MAX_MB);
+  const bufferMsRaw = process.env.MCP_TRACE_BUFFER_MS;
+  const bufferMs = bufferMsRaw === undefined ? 0 : parseInt(bufferMsRaw, 10);
+  const sample = parseFloat(process.env.MCP_TRACE_SAMPLE);
+  _config = {
+    enabled: true,
+    file,
+    maxBytes: (isNaN(maxMB) || maxMB <= 0 ? 50 : maxMB) * 1024 * 1024,
+    // bufferMs default is 0 = immediate fire-and-forget append per event.
+    // This is the right default for spawn-per-call architectures (LENS,
+    // AURUM) where each MCP subprocess gets SIGKILLed after returning
+    // its response — a buffered flush timer rarely fires in time. Set
+    // MCP_TRACE_BUFFER_MS=50 (or higher) to opt in to buffering in
+    // long-running deployments (e.g. F3 Streamable HTTP daemon).
+    bufferMs: isNaN(bufferMs) || bufferMs < 0 ? 0 : bufferMs,
+    sample: isNaN(sample) || sample < 0 || sample > 1 ? 1.0 : sample,
+  };
+  return _config;
+}
+
+// ─── Tool-name attribution context ────────────────────────────────────
+const toolContext = new AsyncLocalStorage();
+
+/**
+ * Wrap a tool handler so any evaluate/evaluateWrite call inside its
+ * async stack picks up the tool name via traceCurrentTool().
+ * Called from src/server.js when registering each tool.
+ *
+ * @param {string} toolName
+ * @param {Function} handler - the original tool callback
+ * @returns {Function} wrapped handler
+ */
+export function withToolName(toolName, handler) {
+  if (!config().enabled) return handler;
+  return async (...args) => toolContext.run(toolName, () => handler(...args));
+}
+
+/** Returns the current tool name in scope, or undefined. */
+export function traceCurrentTool() {
+  return toolContext.getStore();
+}
+
+// ─── Buffer + flush loop ──────────────────────────────────────────────
+let _seq = 0;
+let _buffer = [];
+let _bufferBytes = 0;
+let _flushTimer = null;
+let _flushing = false;
+let _exitHooked = false;
+
+const BUFFER_BYTES_MAX = 64 * 1024;
+
+function scheduleFlush() {
+  if (_flushTimer) return;
+  _flushTimer = setTimeout(flush, config().bufferMs);
+  // Don't keep the event loop alive solely for this timer.
+  if (_flushTimer.unref) _flushTimer.unref();
+}
+
+async function flush() {
+  if (_flushTimer) {
+    clearTimeout(_flushTimer);
+    _flushTimer = null;
+  }
+  if (_buffer.length === 0 || _flushing) return;
+  _flushing = true;
+  const chunk = _buffer.join("");
+  _buffer = [];
+  _bufferBytes = 0;
+  try {
+    await appendFile(config().file, chunk);
+    await maybeRotate();
+  } catch (e) {
+    // Tracer must never break the MCP server. Print to stderr so the
+    // operator notices but don't throw.
+    if (process.env.MCP_TRACE_DEBUG)
+      console.error("[tracer] flush error:", e.message || e);
+  } finally {
+    _flushing = false;
+    if (_buffer.length > 0) scheduleFlush();
+  }
+}
+
+async function maybeRotate() {
+  const cfg = config();
+  if (!cfg.enabled) return;
+  try {
+    const s = await stat(cfg.file);
+    if (s.size <= cfg.maxBytes) return;
+  } catch {
+    return; // file disappeared — nothing to do
+  }
+  try {
+    await rename(cfg.file, `${cfg.file}.1`);
+  } catch (e) {
+    if (process.env.MCP_TRACE_DEBUG)
+      console.error("[tracer] rotate error:", e.message || e);
+  }
+}
+
+// Serialised write queue — used when bufferMs=0 (immediate mode) to
+// preserve emission order while doing fire-and-forget async appends.
+let _writeQueue = Promise.resolve();
+
+function emit(line) {
+  if (config().bufferMs === 0) {
+    // Immediate mode: chain this append onto the write queue. Order
+    // within one process is preserved. Each appendFile call is a single
+    // write() syscall — the data hits the kernel page cache before the
+    // promise settles, so SIGKILL after the chain link resolves is safe
+    // (the kernel flushes its page cache asynchronously regardless of
+    // whether our process is alive).
+    _writeQueue = _writeQueue.then(() =>
+      appendFile(config().file, line).catch((e) => {
+        if (process.env.MCP_TRACE_DEBUG)
+          console.error("[tracer] write error:", e.message || e);
+      }),
+    );
+    // Rotation check piggybacks on the queue so it doesn't race with
+    // writes.
+    _writeQueue = _writeQueue.then(() => maybeRotate());
+    hookExit();
+    return;
+  }
+  // Buffered mode (operator opted in via MCP_TRACE_BUFFER_MS > 0).
+  _buffer.push(line);
+  _bufferBytes += line.length;
+  if (_bufferBytes >= BUFFER_BYTES_MAX) {
+    flush();
+  } else {
+    scheduleFlush();
+  }
+  hookExit();
+}
+
+function hookExit() {
+  if (_exitHooked) return;
+  _exitHooked = true;
+  // beforeExit fires when the loop is about to empty; we get a chance
+  // to drain pending writes / flush the buffer before the process
+  // exits cleanly. SIGTERM that triggers a clean exit also fires this.
+  // SIGKILL (= kill -9) and OOM-killer don't — accept the loss for
+  // those rare cases.
+  process.on("beforeExit", async () => {
+    if (_buffer.length > 0) await flush();
+    await _writeQueue.catch(() => {});
+  });
+}
+
+// ─── Truncate JS expression for the excerpt field ─────────────────────
+const EXCERPT_MAX = 80;
+function excerptOf(expression) {
+  return String(expression).replace(/\s+/g, " ").slice(0, EXCERPT_MAX);
+}
+
+function nextSeq() {
+  return ++_seq;
+}
+
+function nowMs() {
+  return performance.now();
+}
+
+function shouldSample() {
+  const cfg = config();
+  if (cfg.sample >= 1.0) return true;
+  if (cfg.sample <= 0.0) return false;
+  return Math.random() < cfg.sample;
+}
+
+// ─── Public trace API used by connection.js ───────────────────────────
+//
+// trace.start(kind, expression) — begin a non-locked (read) span.
+//   Returns a span handle: { end(), error(msg) }
+//
+// trace.startWrite(expression) — begin a write span (covers
+//   evaluateWrite). Returns { acquired(), released(), error(msg) }.
+//
+// trace itself is exported as a callable for back-compat: trace(kind, info)
+//   logs a single one-shot event. Mostly used internally for tests.
+
+function logOne(kind, info) {
+  if (!config().enabled) return;
+  const line =
+    JSON.stringify({
+      ts: new Date().toISOString(),
+      pid: process.pid,
+      seq: nextSeq(),
+      kind,
+      ...info,
+    }) + "\n";
+  emit(line);
+}
+
+export const trace = Object.assign(logOne, {
+  /**
+   * Begin a read-span around a CDP evaluate() call.
+   * No-op (returns a stub) when tracer is disabled or sample drops.
+   */
+  start(kind, expression) {
+    if (!config().enabled || !shouldSample()) return SPAN_NOOP;
+    const id = nextSeq() + 1; // use the seq of our first emitted event
+    const tool = traceCurrentTool();
+    const t0 = nowMs();
+    logOne(`${kind}.start`, {
+      id,
+      tool,
+      excerpt: excerptOf(expression),
+    });
+    return {
+      end() {
+        logOne(`${kind}.end`, {
+          id,
+          tool,
+          dur_ms: +(nowMs() - t0).toFixed(2),
+        });
+      },
+      error(msg) {
+        logOne(`${kind}.error`, {
+          id,
+          tool,
+          dur_ms: +(nowMs() - t0).toFixed(2),
+          error: String(msg).slice(0, 200),
+        });
+      },
+    };
+  },
+
+  /**
+   * Begin a multi-step write-section around a withWriteLock() block.
+   * Same lifecycle as startWrite (queued/acquired/released) but emits
+   * kind=writeLock.* instead of evaluateWrite.* — keeps the trace
+   * unambiguous about which path took the mutex (single-evaluate
+   * write vs multi-step block).
+   */
+  startSection() {
+    if (!config().enabled || !shouldSample()) return WRITE_SPAN_NOOP;
+    const id = nextSeq() + 1;
+    const tool = traceCurrentTool();
+    const tQueued = nowMs();
+    let tAcquired = 0;
+    logOne("writeLock.queued", { id, tool });
+    return {
+      acquired() {
+        tAcquired = nowMs();
+        logOne("writeLock.acquired", {
+          id,
+          tool,
+          wait_ms: +(tAcquired - tQueued).toFixed(2),
+        });
+      },
+      released() {
+        logOne("writeLock.released", {
+          id,
+          tool,
+          work_ms: +(nowMs() - tAcquired).toFixed(2),
+        });
+      },
+      error(msg) {
+        logOne("writeLock.error", {
+          id,
+          tool,
+          error: String(msg).slice(0, 200),
+        });
+      },
+    };
+  },
+
+  /**
+   * Begin a write-span around an evaluateWrite() call. Captures three
+   * lifecycle events: queued (call entered the wrapper), acquired
+   * (mutex grant) with wait_ms, released (CDP completed) with work_ms.
+   */
+  startWrite(expression) {
+    if (!config().enabled || !shouldSample()) return WRITE_SPAN_NOOP;
+    const id = nextSeq() + 1;
+    const tool = traceCurrentTool();
+    const tQueued = nowMs();
+    let tAcquired = 0;
+    logOne("evaluateWrite.queued", {
+      id,
+      tool,
+      excerpt: excerptOf(expression),
+    });
+    return {
+      acquired() {
+        tAcquired = nowMs();
+        logOne("evaluateWrite.acquired", {
+          id,
+          tool,
+          wait_ms: +(tAcquired - tQueued).toFixed(2),
+        });
+      },
+      released() {
+        logOne("evaluateWrite.released", {
+          id,
+          tool,
+          work_ms: +(nowMs() - tAcquired).toFixed(2),
+        });
+      },
+      error(msg) {
+        logOne("evaluateWrite.error", {
+          id,
+          tool,
+          error: String(msg).slice(0, 200),
+        });
+      },
+    };
+  },
+
+  /** Internal: force-flush pending buffer (used by tests). */
+  async _flush() {
+    await flush();
+  },
+
+  /** Internal: returns current config snapshot (used by tests). */
+  _config() {
+    return { ...config() };
+  },
+
+  /** Internal: reset state (used by tests). */
+  _reset() {
+    _config = null;
+    _seq = 0;
+    _buffer = [];
+    _bufferBytes = 0;
+    if (_flushTimer) {
+      clearTimeout(_flushTimer);
+      _flushTimer = null;
+    }
+    _flushing = false;
+  },
+});
+
+// No-op spans returned when tracing is disabled or sample drops.
+const SPAN_NOOP = Object.freeze({ end() {}, error() {} });
+const WRITE_SPAN_NOOP = Object.freeze({ acquired() {}, released() {}, error() {} });

--- a/tests/concurrency.test.js
+++ b/tests/concurrency.test.js
@@ -1,0 +1,133 @@
+/**
+ * tests/concurrency.test.js
+ *
+ * Tests for the write-tool serialization mutex in src/connection.js.
+ *
+ * The MCP server's CDP client is a module-level singleton shared by every
+ * tool handler. Without serialization, concurrent calls to write tools
+ * (chart_set_symbol, chart_set_timeframe, draw_shape, etc.) interleave on
+ * Chrome's JS thread in arrival order — Chrome's microtask scheduling
+ * decides the "winner", not the calling code. For some operations this is
+ * benign (a quick clock-on-clock race). For others — symbol-load
+ * lifecycle, indicator add+remove, replay state machine, dialog handling —
+ * the result is a corrupted page state.
+ *
+ * The fix: `evaluateWrite()` runs every write under a process-wide
+ * `async-mutex` instance. `withWriteLock(fn)` wraps a multi-step sequence
+ * so multiple evaluates within one logical operation can't be interleaved
+ * by another writer.
+ *
+ * These tests verify the mutex semantics without requiring a running
+ * Chrome + TradingView. The mutex itself is module-level, so we can
+ * exercise it with simulated workloads.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { Mutex } from 'async-mutex';
+
+test('async-mutex serializes concurrent writes in arrival order', async () => {
+  // Mirror the pattern in src/connection.js — process-wide mutex,
+  // each call wraps the critical section in runExclusive.
+  const mutex = new Mutex();
+  const order = [];
+
+  async function fakeWrite(label, ms) {
+    return mutex.runExclusive(async () => {
+      order.push(`start:${label}`);
+      await new Promise(r => setTimeout(r, ms));
+      order.push(`end:${label}`);
+      return label;
+    });
+  }
+
+  // Fire 5 concurrent writes with overlapping work windows.
+  const promises = [
+    fakeWrite('A', 30),
+    fakeWrite('B', 10),
+    fakeWrite('C', 20),
+    fakeWrite('D', 5),
+    fakeWrite('E', 15),
+  ];
+  const results = await Promise.all(promises);
+
+  // Each write must complete before the next one starts. The order
+  // array should be: start:A, end:A, start:B, end:B, ... in arrival
+  // order (Promise.all preserves order of submission for the mutex
+  // queue inside async-mutex).
+  assert.equal(order.length, 10, 'expected 10 markers (5 start + 5 end)');
+  for (let i = 0; i < 5; i++) {
+    const label = String.fromCharCode(65 + i);  // A, B, C, D, E
+    assert.equal(order[i * 2], `start:${label}`, `position ${i * 2} should be start:${label}`);
+    assert.equal(order[i * 2 + 1], `end:${label}`, `position ${i * 2 + 1} should be end:${label}`);
+  }
+  // Results returned in the order the promises were submitted.
+  assert.deepEqual(results, ['A', 'B', 'C', 'D', 'E']);
+});
+
+test('async-mutex withWriteLock-style multi-step sequence is atomic', async () => {
+  const mutex = new Mutex();
+  const log = [];
+
+  // Simulate two clients each doing a "read-modify-write" sequence
+  // (mirrors src/core/chart.js manageIndicator: before-snapshot →
+  // mutation → after-snapshot). Without locking the whole sequence,
+  // a concurrent writer could mutate between our read and our read-
+  // back, producing a stale "before".
+  async function runSequence(id) {
+    return mutex.runExclusive(async () => {
+      const before = log.length;
+      log.push(`${id}:write`);
+      await new Promise(r => setTimeout(r, 10));
+      const after = log.length;
+      // The invariant: nothing else appended between before-snapshot and
+      // after-snapshot inside this critical section. So after === before + 1.
+      return { id, before, after, gained: after - before };
+    });
+  }
+
+  const results = await Promise.all([
+    runSequence('alpha'),
+    runSequence('beta'),
+    runSequence('gamma'),
+  ]);
+
+  for (const r of results) {
+    assert.equal(r.gained, 1, `${r.id} should see exactly its own write inside the lock; saw ${r.gained}`);
+  }
+});
+
+test('connection.js exports evaluateWrite + withWriteLock', async () => {
+  const mod = await import('../src/connection.js');
+  assert.equal(typeof mod.evaluateWrite, 'function', 'evaluateWrite must be exported');
+  assert.equal(typeof mod.withWriteLock, 'function', 'withWriteLock must be exported');
+  assert.equal(typeof mod.evaluate, 'function', 'evaluate must still be exported (read path)');
+  assert.equal(typeof mod.evaluateAsync, 'function', 'evaluateAsync must still be exported');
+});
+
+test('reads do not block on the write mutex', async () => {
+  // The whole point of the read/write split: a long-running write
+  // (chart_set_symbol with a slow symbol-load) must not block reads
+  // (quote_get, chart_get_state) that other consumers depend on. We
+  // simulate this by holding the mutex with a deliberately slow async
+  // op and verifying a "read" (no mutex) completes in parallel.
+  const mutex = new Mutex();
+  let readCompletedBeforeWriteEnded = false;
+
+  const writePromise = mutex.runExclusive(async () => {
+    await new Promise(r => setTimeout(r, 50));
+    return 'write-done';
+  });
+
+  // A "read" does not enter the mutex.
+  const readPromise = (async () => {
+    await new Promise(r => setTimeout(r, 5));
+    // If we got here in 5ms while the write is still running (50ms total),
+    // the read is genuinely concurrent with the write.
+    readCompletedBeforeWriteEnded = true;
+    return 'read-done';
+  })();
+
+  const [readResult] = await Promise.all([readPromise, writePromise]);
+  assert.equal(readResult, 'read-done');
+  assert.ok(readCompletedBeforeWriteEnded, 'read must complete before write releases the mutex');
+});

--- a/tests/tracer.test.js
+++ b/tests/tracer.test.js
@@ -1,0 +1,228 @@
+/**
+ * tests/tracer.test.js — exercises the optional NDJSON tracer in src/tracer.js.
+ *
+ * The tracer is disabled when MCP_TRACE_FILE is unset. These tests set
+ * the env var before importing the module (after each test, _reset()
+ * clears state and the next test reads env afresh).
+ */
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, stat, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+let tmpDir;
+let tracer;
+
+before(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "tracer-test-"));
+});
+
+after(async () => {
+  // Best-effort cleanup; not critical if it fails.
+  try {
+    const { rm } = await import("fs/promises");
+    await rm(tmpDir, { recursive: true, force: true });
+  } catch {}
+});
+
+async function freshTracer(envOverrides = {}) {
+  // Reset cached config and re-import so env changes take effect.
+  delete process.env.MCP_TRACE_FILE;
+  delete process.env.MCP_TRACE_MAX_MB;
+  delete process.env.MCP_TRACE_BUFFER_MS;
+  delete process.env.MCP_TRACE_SAMPLE;
+  for (const [k, v] of Object.entries(envOverrides)) process.env[k] = v;
+  // Bust the module cache so a fresh _config() read happens.
+  const mod = await import(`../src/tracer.js?t=${Date.now()}`);
+  mod.trace._reset();
+  return mod;
+}
+
+test("tracer disabled when MCP_TRACE_FILE is unset — no file written", async () => {
+  const mod = await freshTracer({});
+  const span = mod.trace.start("evaluate", "1 + 1");
+  span.end();
+  await mod.trace._flush();
+  assert.equal(mod.trace._config().enabled, false);
+});
+
+test("tracer writes one NDJSON line per emit", async () => {
+  const file = join(tmpDir, "single.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  // Direct one-shot call.
+  mod.trace("custom.event", { foo: "bar", n: 42 });
+  await mod.trace._flush();
+  const contents = await readFile(file, "utf8");
+  const lines = contents.trim().split("\n");
+  assert.equal(lines.length, 1);
+  const parsed = JSON.parse(lines[0]);
+  assert.equal(parsed.kind, "custom.event");
+  assert.equal(parsed.foo, "bar");
+  assert.equal(parsed.n, 42);
+  assert.equal(typeof parsed.ts, "string");
+  assert.equal(typeof parsed.pid, "number");
+  assert.equal(typeof parsed.seq, "number");
+});
+
+test("tracer captures evaluate span — start + end with dur_ms", async () => {
+  const file = join(tmpDir, "evaluate.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  const span = mod.trace.start("evaluate", "(function() { return 42; })()");
+  await new Promise((r) => setTimeout(r, 5));
+  span.end();
+  await mod.trace._flush();
+  const lines = (await readFile(file, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0].kind, "evaluate.start");
+  assert.equal(lines[1].kind, "evaluate.end");
+  assert.equal(lines[0].id, lines[1].id);
+  assert.equal(
+    typeof lines[1].dur_ms,
+    "number",
+    "end event must record dur_ms",
+  );
+  assert.ok(lines[1].dur_ms >= 4, "dur_ms reflects the sleep");
+  assert.ok(
+    lines[0].excerpt.startsWith("(function() { return 42; })()"),
+    "excerpt captures the expression",
+  );
+});
+
+test("tracer captures evaluateWrite span — queued + acquired + released", async () => {
+  const file = join(tmpDir, "evaluateWrite.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  const span = mod.trace.startWrite("/* setSymbol */");
+  await new Promise((r) => setTimeout(r, 3)); // queue wait
+  span.acquired();
+  await new Promise((r) => setTimeout(r, 5)); // mutex work
+  span.released();
+  await mod.trace._flush();
+  const lines = (await readFile(file, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.equal(lines.length, 3);
+  assert.equal(lines[0].kind, "evaluateWrite.queued");
+  assert.equal(lines[1].kind, "evaluateWrite.acquired");
+  assert.equal(lines[2].kind, "evaluateWrite.released");
+  // All three share the same id (lifecycle of one span)
+  assert.equal(lines[0].id, lines[1].id);
+  assert.equal(lines[1].id, lines[2].id);
+  assert.ok(lines[1].wait_ms >= 2, "wait_ms reflects queue time");
+  assert.ok(lines[2].work_ms >= 4, "work_ms reflects critical-section time");
+});
+
+test("tracer attributes tool name via withToolName context", async () => {
+  const file = join(tmpDir, "tool-name.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  const wrapped = mod.withToolName("chart_set_symbol", async () => {
+    const span = mod.trace.start("evaluate", "test");
+    span.end();
+  });
+  await wrapped();
+  await mod.trace._flush();
+  const lines = (await readFile(file, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0].tool, "chart_set_symbol");
+  assert.equal(lines[1].tool, "chart_set_symbol");
+});
+
+test("tracer omits tool field when no context is active", async () => {
+  const file = join(tmpDir, "no-tool.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  // Called outside any withToolName wrapper.
+  const span = mod.trace.start("evaluate", "x");
+  span.end();
+  await mod.trace._flush();
+  const lines = (await readFile(file, "utf8")).trim().split("\n").map(JSON.parse);
+  // tool field is omitted (undefined when traceCurrentTool() returns nothing,
+  // which JSON.stringify drops). So no "tool" key.
+  assert.ok(!("tool" in lines[0]), `unexpected tool field: ${lines[0].tool}`);
+});
+
+test("withToolName is a no-op when tracer is disabled", async () => {
+  const mod = await freshTracer({});
+  const inner = async () => "result";
+  const wrapped = mod.withToolName("any_tool", inner);
+  // When disabled, withToolName returns the original handler unchanged.
+  assert.equal(wrapped, inner);
+});
+
+test("ordering preserved within a single process — seq is monotonic", async () => {
+  const file = join(tmpDir, "ordering.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  for (let i = 0; i < 20; i++) {
+    mod.trace("burst", { i });
+  }
+  await mod.trace._flush();
+  const lines = (await readFile(file, "utf8")).trim().split("\n").map(JSON.parse);
+  assert.equal(lines.length, 20);
+  for (let i = 1; i < lines.length; i++) {
+    assert.ok(
+      lines[i].seq > lines[i - 1].seq,
+      `seq must be monotonic (line ${i} seq=${lines[i].seq} not > ${lines[i - 1].seq})`,
+    );
+  }
+});
+
+test("size-based rotation: file exceeding MCP_TRACE_MAX_MB is renamed to .1", async () => {
+  const file = join(tmpDir, "rotate.log");
+  // Pre-fill the file so the very next flush triggers rotation.
+  // 0.001 MB = 1024 bytes; we'll write more than that.
+  await writeFile(file, "x".repeat(2000));
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_MAX_MB: "0.001",
+    MCP_TRACE_BUFFER_MS: "10",
+  });
+  // Emit one event — flush will check size and rotate.
+  mod.trace("trigger", {});
+  await mod.trace._flush();
+  const s1 = await stat(file).catch(() => null);
+  const sRotated = await stat(`${file}.1`).catch(() => null);
+  assert.ok(sRotated !== null, "rotated file .1 must exist");
+  // After rotation the active file should be either small (just the
+  // post-rotation events) or absent if no further writes happened.
+  if (s1 !== null) {
+    assert.ok(
+      s1.size < 2000,
+      "post-rotation file should be smaller than the pre-rotation size",
+    );
+  }
+});
+
+test("sampling=0 emits nothing", async () => {
+  const file = join(tmpDir, "no-sample.log");
+  const mod = await freshTracer({
+    MCP_TRACE_FILE: file,
+    MCP_TRACE_BUFFER_MS: "10",
+    MCP_TRACE_SAMPLE: "0",
+  });
+  for (let i = 0; i < 10; i++) {
+    const span = mod.trace.start("evaluate", "x");
+    span.end();
+    const wspan = mod.trace.startWrite("y");
+    wspan.acquired();
+    wspan.released();
+  }
+  await mod.trace._flush();
+  const contents = await readFile(file, "utf8").catch(() => "");
+  // sample=0 means span starts return SPAN_NOOP — zero lines emitted.
+  assert.equal(contents, "");
+});


### PR DESCRIPTION
## Why

Two issues this PR addresses, both about **correctness under concurrency**, not throughput:

### 1. Multi-client write race on a single CDP connection

The MCP server exposes write-class tools (`chart_set_symbol`, `chart_set_timeframe`, `chart_manage_indicator`, `draw_*`, `alert_*`, `pane_set_*`, `pine_*`, `replay_*`, `ui_*`, `watchlist_*`) that mutate TradingView page state via `Runtime.evaluate` over one Chrome DevTools Protocol connection. CDP supports concurrent in-flight commands (responses are matched by `id`), so two write `evaluate()` calls reach Chrome on the same connection and run in arrival order on Chrome's single JS thread.

For **reads** this is fine — interleaving two `quote_get` calls just returns two independent results. For **writes** it's a correctness problem: two rapid `chart_set_symbol` calls from different clients (or the same client's async fan-out) race on TradingView's symbol-load lifecycle. The "winner" depends on Chrome's microtask scheduling rather than caller arrival order, and the page can be left in a state where the in-memory symbol disagrees with the rendered chart — until the next manual interaction.

This affects any deployment with >1 concurrent caller — common in MCP server setups where multiple agents (or one agent fanning out async tool calls) hit the same instance.

### 2. TradingView API rate-limit cooperation

TradingView throttles internal API endpoints (symbol search, indicator creation, layout save) per-second. Concurrent write fan-out can trip these limits and return malformed/partial state that the EA/agent has to retry — multiplying load and pushing further into the throttled region. A mutex paces writes naturally without explicit per-tool sleep tables.

### 3. State isolation guarantee for multi-step writes

`chart_manage_indicator` and similar tools take a before-snapshot, mutate, then take an after-snapshot. Without a lock, another client's write between the two snapshots is silently attributed to this tool's diff. The added `withWriteLock(fn)` helper provides an atomic critical section for multi-step writes — guaranteeing snapshot diffs reflect only this tool's work.

---

## What

### Commit 1 — `feat(connection): serialize write tools with a process-wide async mutex`

- New `evaluateWrite(expression, opts)` in `src/connection.js` wrapping `evaluate()` inside an [`async-mutex`](https://www.npmjs.com/package/async-mutex) critical section. Per-process scope: one MCP server = one mutex. Concurrent writes serialize FIFO; reads bypass the mutex entirely.
- New `withWriteLock(fn)` for multi-step writes that need atomicity across 2+ inner `evaluate()` calls. Callback receives the unlocked `evaluate()` so the inner sequence runs uninterrupted.
- 10 core modules updated to use `evaluateWrite` / `withWriteLock` where mutating: `chart`, `drawing`, `alerts`, `pane`, `indicators`, `pine`, `replay`, `batch`, `watchlist`, `ui`. Read-only handlers stay on `evaluate()`.
- New dependency: `async-mutex@^0.5.0` (tiny, zero-runtime-overhead Promise-based mutex; widely used).
- Tests: `tests/concurrency.test.js` — 4 cases covering single-writer, concurrent-writers-serialize, read-bypass, exception-releases-lock.

### Commit 2 — `feat(tracer): optional NDJSON packet tracer + bench harness + docs`

Optional observability layer to validate the mutex (and any future write-path change) live. **Off by default and zero-cost when off** — one `if (!config().enabled)` short-circuit per call.

- New `src/tracer.js` (~290 lines) — emits NDJSON to a file path set via `MCP_TRACE_FILE`. Per-event fields: `ts`, `pid`, `seq`, `kind`, `id`, `tool`, `excerpt`, `dur_ms`, `wait_ms`, `work_ms`, `error`.
- Tool attribution via AsyncLocalStorage (`withToolName(name, handler)`) — `src/server.js` monkey-patches `server.tool` so every registered handler runs inside a tool-named context. Inner `evaluate` calls inside `withWriteLock` inherit the tool name correctly across nested async hops.
- Event kinds: `evaluate.{start,end,error}`, `evaluateWrite.{queued,acquired,released,error}` (single-evaluate writes), `writeLock.{queued,acquired,released,error}` (multi-step writes via `withWriteLock`).
- Configurable: `MCP_TRACE_FILE` (path), `MCP_TRACE_BUFFER_MS` (default 0 = fire-and-forget for SIGKILL safety), `MCP_TRACE_MAX_MB` (rotation, default 50), `MCP_TRACE_SAMPLE` (default 1.0).
- Multi-process safe: POSIX `write()` under PIPE_BUF (4KB) is atomic; lines stay well under. Multiple MCP subprocesses appending to the same file interleave cleanly at line granularity. (Important for stdio-spawn-per-call deployment patterns.)
- Tests: `tests/tracer.test.js` — 10 cases covering disabled-when-unset, NDJSON shape, sampling, rotation, tool attribution, error events, multi-PID isolation.
- Bench: `scripts/bench-mutex.mjs` — 3 scenarios (single writer, concurrent writers serialize, concurrent reads bypass).
- Docs: `docs/TRACING.md` — operator guide (env vars, NDJSON schema, jq recipes, multi-process notes). README section linking to it.

---

## Compatibility

- **Default behavior unchanged**. `evaluate()` signature/semantics identical. Tracer disabled when `MCP_TRACE_FILE` unset.
- **Per-process scope** for the mutex. If a deployment runs multiple MCP processes against the same Chrome (legacy stdio per-consumer pattern), each MCP gets its own mutex — the race across processes still exists. The natural mitigation is one MCP serving many consumers over Streamable HTTP, where the mutex covers all callers. That transport change is out of scope for this PR.
- **No breaking changes** to tool schemas, response shapes, or wire format.

---

## Validation

Live validation against a running TradingView Desktop with AURUM (the consumer in our deployment) issuing real MCP tool calls:

| Path | Test stimulus | Result |
|---|---|---|
| `evaluate` read | `morning_brief` query (188 calls) | 261/261 start↔end pairs, 100% tool-attributed |
| `evaluateWrite` mutex | `morning_brief` write subcomponents (7 spans) | full `queued → acquired (wait_ms 0.06–0.60ms) → released (work_ms 1.7–504ms)` lifecycles |
| `withWriteLock` multi-step | `chart_manage_indicator` (add RSI) | 1 complete `writeLock.{queued,acquired,released}` triplet + 3 nested `evaluate` pairs inside the critical section, all on same PID, tool attribution preserved through AsyncLocalStorage |
| Multi-PID isolation | 37 MCP subprocess spawns across two test windows | clean per-process `seq` ordering, no event mixing |

Concrete writeLock evidence from the live AURUM session:

```
11:33:31.531 pid=26274 id=2  writeLock.queued    tool=chart_manage_indicator
11:33:31.537 pid=26274 id=2  writeLock.acquired  tool=chart_manage_indicator  wait_ms=6.08
11:33:31.538 pid=26274 id=5  evaluate.start      tool=chart_manage_indicator  (pre-snapshot getAllStudies)
11:33:31.692 pid=26274 id=5  evaluate.end        tool=chart_manage_indicator  dur_ms=154.26
11:33:31.692 pid=26274 id=8  evaluate.start      tool=chart_manage_indicator  (createStudy RSI)
11:33:31.715 pid=26274 id=8  evaluate.end        tool=chart_manage_indicator  dur_ms=22.67
11:33:33.215 pid=26274 id=11 evaluate.start      tool=chart_manage_indicator  (post-snapshot getAllStudies)
11:33:33.217 pid=26274 id=11 evaluate.end        tool=chart_manage_indicator  dur_ms=1.79
11:33:33.217 pid=26274 id=2  writeLock.released  tool=chart_manage_indicator  work_ms=1679.86
```

`work_ms` matches measured elapsed (1679.86 vs 1680.0). Tool attribution survives the nested async hops correctly.

Test suite: `npm test` → 4 concurrency + 10 tracer tests pass, plus existing e2e + pine_analyze suites.

---

## Appendix — bench numbers (not the headline)

`scripts/bench-mutex.mjs` against a stubbed evaluate (no real Chrome):

| Scenario | Behavior |
|---|---|
| B1 — single writer | baseline, no contention |
| B2 — 5 concurrent writers, 100ms simulated work | strict FIFO serialization, ~504ms total (5×100ms + ~ms-scale mutex overhead) |
| B3 — 5 concurrent reads | bypass the mutex, run in parallel |

These confirm the mutex behaves as designed. Performance is a side-effect of correctness here, not the goal.

---

## Out of scope (follow-ups)

- **Streamable HTTP transport** — would make the mutex cross-consumer effective without changing this PR's surface.
- **CDP reconnect hardening** — orthogonal to the race; tracked separately.
- **Tool-level write classification audit** — verify all mutating tools call `evaluateWrite`/`withWriteLock` and all read-only ones stay on `evaluate`. Spot-checked in this PR but a systematic sweep could happen in a follow-up.
