### PR TITLE
Auto-fix Windows AppX loopback isolation in tv_launch

### DIFF
--- a/src/cli/commands/health.js
+++ b/src/cli/commands/health.js
@@ -11,9 +11,11 @@ register('launch', {
   options: {
     port: { type: 'string', short: 'p', description: 'CDP port (default 9222)' },
     'no-kill': { type: 'boolean', description: 'Do not kill existing instances' },
+    'no-loopback-fix': { type: 'boolean', description: 'On Windows AppX installs, skip the CheckNetIsolation LoopbackExempt fix (UAC prompt)' },
   },
   handler: (opts) => core.launch({
     port: opts.port ? Number(opts.port) : undefined,
     kill_existing: !opts['no-kill'],
+    fix_loopback: !opts['no-loopback-fix'],
   }),
 });

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,17 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  if (!tvPath && platform === 'win32') {
+    try {
+      const psCmd = `powershell -NoProfile -Command "(Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1).InstallLocation"`;
+      const installLoc = execSync(psCmd, { timeout: 5000 }).toString().trim();
+      if (installLoc) {
+        const candidate = `${installLoc}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -159,9 +159,40 @@ export async function uiState() {
   return { success: true, ...state };
 }
 
-export async function launch({ port, kill_existing } = {}) {
+function isAppxPath(p) {
+  return process.platform === 'win32' && /\\WindowsApps\\/i.test(p);
+}
+
+function getAppxPfn() {
+  try {
+    const out = execSync(
+      `powershell -NoProfile -Command "(Get-AppxPackage -Name '*TradingView*' | Select-Object -First 1).PackageFamilyName"`,
+      { timeout: 5000 }
+    ).toString().trim();
+    return out || null;
+  } catch { return null; }
+}
+
+function isLoopbackExempt(pfn) {
+  try {
+    const out = execSync('CheckNetIsolation LoopbackExempt -s', { timeout: 5000 }).toString().toLowerCase();
+    return out.includes(pfn.toLowerCase());
+  } catch { return false; }
+}
+
+function applyLoopbackExempt(pfn) {
+  // Triggers a UAC prompt. Returns true if the exemption is present after the attempt.
+  try {
+    const psCmd = `Start-Process cmd.exe -ArgumentList '/c','CheckNetIsolation LoopbackExempt -a -n=${pfn}' -Verb RunAs -Wait -WindowStyle Hidden`;
+    execSync(`powershell -NoProfile -Command "${psCmd.replace(/"/g, '\\"')}"`, { timeout: 60000, stdio: 'ignore' });
+  } catch { /* user may have denied UAC */ }
+  return isLoopbackExempt(pfn);
+}
+
+export async function launch({ port, kill_existing, fix_loopback } = {}) {
   const cdpPort = port || 9222;
   const killFirst = kill_existing !== false;
+  const autoFixLoopback = fix_loopback !== false;
   const platform = process.platform;
 
   const pathMap = {
@@ -222,6 +253,19 @@ export async function launch({ port, kill_existing } = {}) {
     throw new Error(`TradingView not found on ${platform}. Searched: ${candidates.join(', ')}. Launch manually with: /path/to/TradingView --remote-debugging-port=${cdpPort}`);
   }
 
+  const appx = { detected: false, pfn: null, loopback_exempt: null, exempt_applied: false };
+  if (isAppxPath(tvPath)) {
+    appx.detected = true;
+    appx.pfn = getAppxPfn();
+    if (appx.pfn) {
+      appx.loopback_exempt = isLoopbackExempt(appx.pfn);
+      if (!appx.loopback_exempt && autoFixLoopback) {
+        appx.loopback_exempt = applyLoopbackExempt(appx.pfn);
+        appx.exempt_applied = appx.loopback_exempt;
+      }
+    }
+  }
+
   if (killFirst) {
     try {
       if (platform === 'win32') execSync('taskkill /F /IM TradingView.exe', { timeout: 5000 });
@@ -250,13 +294,19 @@ export async function launch({ port, kill_existing } = {}) {
           success: true, platform, binary: tvPath, pid: child.pid,
           cdp_port: cdpPort, cdp_url: `http://localhost:${cdpPort}`,
           browser: info.Browser, user_agent: info['User-Agent'],
+          ...(appx.detected ? { appx } : {}),
         };
       }
     } catch { /* retry */ }
   }
 
+  let warning = 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.';
+  if (appx.detected && appx.pfn && !appx.loopback_exempt) {
+    warning = `TradingView is installed as a Windows Store (AppX) package and is not on the LoopbackExempt list, so its CDP port is unreachable from desktop processes. Run this command in an elevated terminal and relaunch: CheckNetIsolation LoopbackExempt -a -n=${appx.pfn}`;
+  }
   return {
     success: true, platform, binary: tvPath, pid: child.pid, cdp_port: cdpPort, cdp_ready: false,
-    warning: 'TradingView launched but CDP not responding yet. It may still be loading. Try tv_health_check in a few seconds.',
+    ...(appx.detected ? { appx } : {}),
+    warning,
   };
 }

--- a/src/tools/health.js
+++ b/src/tools/health.js
@@ -18,11 +18,12 @@ export function registerHealthTools(server) {
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 
-  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux.', {
+  server.tool('tv_launch', 'Launch TradingView Desktop with Chrome DevTools Protocol (remote debugging) enabled. Auto-detects install location on Mac, Windows, and Linux. On Windows AppX (Microsoft Store) installs, will offer to add a LoopbackExempt entry via an elevated UAC prompt so the CDP port is reachable from desktop processes.', {
     port: z.coerce.number().optional().describe('CDP port (default 9222)'),
     kill_existing: z.coerce.boolean().optional().describe('Kill existing TradingView instances first (default true)'),
-  }, async ({ port, kill_existing }) => {
-    try { return jsonResult(await core.launch({ port, kill_existing })); }
+    fix_loopback: z.coerce.boolean().optional().describe('On Windows AppX installs, prompt for UAC and add the package to CheckNetIsolation LoopbackExempt if missing (default true)'),
+  }, async ({ port, kill_existing, fix_loopback }) => {
+    try { return jsonResult(await core.launch({ port, kill_existing, fix_loopback })); }
     catch (err) { return jsonResult({ success: false, error: err.message }, true); }
   });
 }


### PR DESCRIPTION
## Problem

When TradingView is installed from the Microsoft Store (AppX package), the CDP port bound by `--remote-debugging-port=9222` becomes unreachable from desktop processes due to Windows AppContainer loopback isolation. The MCP server fails to connect even though TradingView is running with the debug flag — `Get-NetTCPConnection` confirms TradingView binds `127.0.0.1:9222`, but `curl` and the MCP server cannot reach it.

This affects every Windows user who installed TradingView from the Store. After the previous AppX path-resolution change, `tv_launch` could find and start TradingView, but CDP was still silently unreachable.

## Fix

`tv_launch` now detects AppX installs (path matches `\WindowsApps\`), retrieves the Package Family Name via `Get-AppxPackage`, checks `CheckNetIsolation LoopbackExempt -s`, and applies the exemption via an elevated UAC prompt when missing.

- New optional param `fix_loopback` (default `true`). Pass `false` to skip the UAC prompt.
- CLI gains `--no-loopback-fix` flag.
- Return value gains an `appx: { detected, pfn, loopback_exempt, exempt_applied }` object on AppX installs.
- If CDP still doesn't respond on an AppX install without the exemption, the `warning` field now contains the exact command to run manually.

## Backwards compatibility

`fix_loopback` defaults to `true`; existing callers benefit automatically. On non-Windows or non-AppX Windows installs the new code is inert.

## Test plan

- [x] Verified on Windows 11 with Microsoft Store TradingView 3.1.0.7818
- [x] Confirmed CDP unreachable before exemption; reachable after
- [x] Smoke-loaded all three modified modules with `node --import`
- [x] Confirmed helpers detect existing exemption correctly (`isLoopbackExempt` returns `true` after applying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)