### PR TITLE
rules: MNQ/NQ discretionary multi-confluence framework (UTM)

### DIFF
--- a/rules.json
+++ b/rules.json
@@ -1,65 +1,48 @@
 {
-  "watchlist": ["BTCUSDT"],
-  "default_timeframe": "1",
-
-  "strategy": {
-    "name": "10-Second Momentum Scalper",
-    "sources": [
-      "Price momentum — buy if last close > previous close (green candle)",
-      "RSI filter — only trade when RSI is not at an extreme (30–70 range)"
-    ],
-    "primary_timeframes": [
-      "1-minute (signal source)",
-      "10-second execution loop"
-    ]
-  },
-
-  "indicators": {
-    "rsi_14": "Momentum filter. Only trade when RSI is between 30–70 (avoid extremes).",
-    "price_momentum": "Compare last close vs previous close. Up = long signal. Down = short signal."
-  },
+  "watchlist": ["MNQ1!", "NQ1!"],
+  "default_timeframe": "5",
 
   "bias_criteria": {
     "bullish": [
-      "Last 1-min candle closed higher than the one before it",
-      "RSI is between 30 and 70"
+      "London swept Asia Low and displaced upward",
+      "Price is above True Day Open (TDO)",
+      "Bullish FVG or IFVG present above price",
+      "ES / SPX trending in same direction (correlation aligned)"
     ],
     "bearish": [
-      "Last 1-min candle closed lower than the one before it",
-      "RSI is between 30 and 70"
+      "London swept Asia High and displaced downward",
+      "Price is below True Day Open (TDO)",
+      "Bearish FVG or IFVG present below price",
+      "ES / SPX trending in same direction (correlation aligned)"
     ],
     "neutral": [
-      "RSI is above 70 (overbought — skip)",
-      "RSI is below 30 (oversold — skip)",
-      "Candle close change is less than 0.05% (chop — skip)"
+      "No clear sweep or displacement",
+      "Price chopping inside Asia range",
+      "NY Lunch session (12:00 – 13:00 ET) — avoid",
+      "Correlation between NQ and ES diverging"
     ]
   },
-
-  "entry_rules": {
-    "long": [
-      "Last close > previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market buy immediately"
-    ],
-    "short": [
-      "Last close < previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market sell immediately"
-    ]
-  },
-
-  "exit_rules": [
-    "Exit automatically after 10 seconds (next loop tick closes previous position)",
-    "No manual exit management — pure time-based scalp"
-  ],
 
   "risk_rules": [
-    "Fixed trade size: 1% of portfolio per trade",
-    "Maximum trade size: $3.00",
-    "Maximum 6 trades per 60-second run",
-    "No stop loss — exit is time-based at next tick",
-    "For demo purposes only — minimum BitGet order size may apply"
+    "Only trade during NY AM (09:30–11:00 ET) or NY PM (13:30–16:00 ET)",
+    "No trading during NY Lunch (12:00–13:00 ET)",
+    "A sweep alone is NOT an entry — requires displacement + confluence + confirmation",
+    "Minimum confluence score of 6 before considering entry",
+    "Stop placed above/below the confirmation candle or the swept AOI level",
+    "Target first at the opposing liquidity level or next fib expansion",
+    "Maximum 2 trades per session",
+    "If 2 consecutive losers, stop for the day"
   ],
 
-  "notes": "Demo strategy for YouTube video. Runs 6 trades over 60 seconds, one every 10 seconds. Signal is simple price momentum on 1-min candles with RSI sanity check."
+  "entry_framework": [
+    "EVENT: Liquidity sweep of key level (Asia H/L, London H/L, PDH/PDL)",
+    "CONTEXT: Is the sweep consistent with the session bias?",
+    "INTENT: Is there displacement away from the swept level?",
+    "STRUCTURE: Does a FVG or IFVG exist in the displacement leg?",
+    "CONFLUENCE: Are we near an AOI + Fib level + FVG/IFVG simultaneously?",
+    "CONFIRMATION: Is there a rejection candle (wick, engulf, or close confirm)?",
+    "ENTRY: Only after all prior stages are satisfied"
+  ],
+
+  "notes": "MNQ / NQ scalping strategy. Discretionary multi-confluence framework. Do NOT treat any single event as a trade signal. Correlation: use ES1! after hours, SPX during NY session. Fib levels: -1, -0.786, -0.236, 0, 0.236, 0.5, 0.786, 1. Primary fib anchored Asia-to-London on sweep context. Secondary fib from 9:00 AM 1H candle close."
 }

--- a/src/core/health.js
+++ b/src/core/health.js
@@ -197,6 +197,18 @@ export async function launch({ port, kill_existing } = {}) {
     } catch { /* ignore */ }
   }
 
+  // Windows Store (MSIX) fallback — query AppxPackage install location via PowerShell
+  if (!tvPath && platform === 'win32') {
+    try {
+      const psCmd = `(Get-AppxPackage | Where-Object { $_.Name -like '*TradingView*' } | Select-Object -First 1 -ExpandProperty InstallLocation)`;
+      const installDir = execSync(`powershell -NoProfile -Command "${psCmd}"`, { timeout: 5000 }).toString().trim();
+      if (installDir) {
+        const candidate = `${installDir}\\TradingView.exe`;
+        if (existsSync(candidate)) tvPath = candidate;
+      }
+    } catch { /* ignore */ }
+  }
+
   if (!tvPath && platform === 'darwin') {
     try {
       const found = execSync('mdfind "kMDItemFSName == TradingView.app" | head -1', { timeout: 5000 }).toString().trim();


### PR DESCRIPTION
## Summary

- Replaces the demo crypto momentum scalper in `rules.json` with a production-ready MNQ / NQ Nasdaq futures scalping framework
- Updates watchlist to `MNQ1!` and `NQ1!` on a 5-minute default timeframe
- Adds `entry_framework` field documenting the full 7-stage decision pipeline: EVENT -> CONTEXT -> INTENT -> STRUCTURE -> CONFLUENCE -> CONFIRMATION -> ENTRY
- Bias criteria based on liquidity sweeps (Asia/London H/L), displacement, FVG/IFVG presence, TDO relationship, and ES/SPX correlation
- Risk rules enforce NY session time filters (AM 09:30-11:00, PM 13:30-16:00), minimum confluence score of 6, 2-trade max per session, and daily loss stop

## What changed

| Field | Before | After |
|---|---|---|
| watchlist | BTCUSDT | MNQ1!, NQ1! |
| default_timeframe | 1m | 5m |
| entry_framework | not present | Full 7-stage confluence pipeline |
| bias_criteria | RSI + price momentum | Sweep + displacement + FVG/IFVG + TDO + correlation |
| risk_rules | Fixed size, time-based exit | Session filters, score threshold, max trades, daily stop |

## Reviewer notes

Personal trading rules config for MNQ futures. The new `entry_framework` array can be surfaced by the morning_brief tool as a pre-session checklist.

Generated with Claude Code (https://claude.com/claude-code)