### PR TITLE
ICT indicator: live bias override + sessions/PDH-PWH levels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,53 @@
-# TradingView MCP — Claude Instructions
+# CLAUDE.md
 
-68 tools for reading and controlling a live TradingView Desktop chart via CDP (port 9222).
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Decision Tree — Which Tool When
+## What this is
+
+A local MCP server + CLI (`tv`) that bridges Claude Code to a live TradingView Desktop app via the Chrome DevTools Protocol (CDP, port 9222). 81 MCP tools for reading chart state, developing Pine Script, driving chart UI, and running a rules-based "morning brief" over a watchlist. No data leaves the machine; no TradingView servers are contacted directly — everything goes through the already-authenticated Desktop app.
+
+## Development
+
+### Commands
+
+```bash
+npm install
+npm run test:unit    # offline, no TradingView needed — cli.test.js + pine_analyze.test.js
+npm run test:cli     # offline — CLI help/exit-code/error-handling tests
+npm test              # ⚠️ also runs tests/e2e.test.js, which REQUIRES TradingView Desktop
+npm run test:e2e      #    running with --remote-debugging-port=9222 — will hang/fail without it
+npm run test:all      # unit + cli + e2e together
+
+node --test --test-name-pattern="<substring>" tests/cli.test.js   # run a single test by name
+tv status              # (after `npm link`) verify the CDP connection to TradingView
+```
+
+There is no lint or build step configured in `package.json` — don't invent one.
+
+When changing anything under `src/`, prefer `npm run test:unit` first since it doesn't require TradingView running. Only reach for `test:e2e` when you have TradingView Desktop open with CDP enabled (`./scripts/launch_tv_debug_mac.sh` or the Windows/Linux equivalents, or the `tv_launch` tool).
+
+### Architecture
+
+Three interfaces share one core — always add new capability to `core/` first, then thin wrappers on top:
+
+- **`src/core/*.js`** — the actual logic. Talks to TradingView exclusively through `src/connection.js`, which holds a single retried CDP client and an `evaluate(expression)` helper that runs JS inside the TradingView page's context. `KNOWN_PATHS` in that file lists unofficial TradingView internals (e.g. `window.TradingViewApi._activeChartWidgetWV`) discovered by probing — see `RESEARCH.md` for how those were found.
+- **`src/tools/*.js`** — MCP tool definitions: zod input schema + call into the matching `core/*.js` function + `jsonResult()` (from `_format.js`) to wrap the response. Each file exports a `registerXTools(server)` function; all of them are registered in `src/server.js`, which also carries the tool-selection guide baked into the MCP server's `instructions` field.
+- **`src/cli/commands/*.js`** — CLI wrappers around the *same* core functions, exposed as the `tv` bin (`src/cli/index.js`) through a small zero-dependency router (`src/cli/router.js`, built on `node:util.parseArgs`).
+
+So a new feature is: one function in `core/`, then a matching entry in `tools/` and/or `cli/commands/`. Keep `core/` as the single source of truth — MCP and CLI wrappers should stay thin.
+
+Other structure:
+- **`skills/*/SKILL.md`** — step-by-step workflows for multi-tool tasks (`pine-develop`, `chart-analysis`, `multi-symbol-scan`, `replay-practice`, `strategy-report`). Read the relevant one before improvising a workflow that already has a documented procedure — `pine-develop` in particular defines the write → push → compile → fix-errors → screenshot loop for Pine Script work.
+- **`rules.json`** (tracked in git, `rules.example.json` is the blank template) — the user's watchlist, bias criteria, and risk rules; `morning_brief` reads it automatically.
+- **`scripts/current.pine`** (gitignored scratch file) — working buffer for the Pine Editor push/pull scripts (`scripts/pine_push.js`, `scripts/pine_pull.js`), used by the `pine-develop` workflow.
+- **`ICT_STRATEGY_SPEC.md`** — living spec for an in-progress custom ICT/smart-money-concepts indicator built on top of this server; not part of the MCP server itself, just a working doc for that side project.
+
+### Known fragility
+
+- `pine_push.js` / `pine_pull.js` locate the Pine Editor's Monaco instance by walking React-fiber internals off `.monaco-editor.pine-editor-monaco` DOM nodes. TradingView can leave more than one such element in the DOM (a stale hidden instance ahead of the live one) — the code must scan all matches for the one whose fiber actually exposes a `monacoEnv`, not just take the first `querySelector` hit, or injection silently fails with "Could not inject into Pine editor".
+- Symbol resolution (`chart_set_symbol` / `tv symbol --set`) goes through TradingView's own search and can resolve a bare ticker to an unexpected instrument — e.g. `GBPUSD` resolving to a CME futures contract instead of spot forex, depending on the account's linked broker. Prefer exchange-qualified symbols (`OANDA:GBPUSD`, not `GBPUSD`/`FX:GBPUSD`) and verify the result with `chart_get_state` / `tv state` (check the exchange, not just the ticker) after setting.
+
+## Tool Selection — Decision Tree
 
 ### "What's on my chart right now?"
 1. `chart_get_state` → symbol, timeframe, chart type, list of all indicators with entity IDs
@@ -33,8 +78,13 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 6. `data_get_ohlcv` with `summary: true` → price action summary
 7. `capture_screenshot` → visual confirmation
 
+### "Run my morning routine"
+1. `morning_brief` → scans watchlist from `rules.json`, reads indicators, applies bias/risk criteria
+2. `session_save` → persist today's brief to `~/.tradingview-mcp/sessions/`
+3. `session_get` → retrieve today's (or yesterday's) saved brief for comparison
+
 ### "Change the chart"
-- `chart_set_symbol` → switch ticker (e.g., "AAPL", "ES1!", "NYMEX:CL1!")
+- `chart_set_symbol` → switch ticker (e.g., "AAPL", "ES1!", "NYMEX:CL1!") — see symbol-resolution caveat above
 - `chart_set_timeframe` → switch resolution (e.g., "1", "5", "15", "60", "D", "W")
 - `chart_set_type` → switch chart style (Candles, HeikinAshi, Line, Area, Renko, etc.)
 - `chart_manage_indicator` → add or remove studies (use full name: "Relative Strength Index", not "RSI")
@@ -42,6 +92,7 @@ Use `study_filter` parameter to target a specific indicator by name substring (e
 - `chart_set_visible_range` → zoom to exact date range (unix timestamps)
 
 ### "Work on Pine Script"
+Follow the `pine-develop` skill. Summary:
 1. `pine_set_source` → inject code into editor
 2. `pine_smart_compile` → compile with auto-detection + error check
 3. `pine_get_errors` → read compilation errors
@@ -119,11 +170,8 @@ These tools can return large payloads. Follow these rules to avoid context bloat
 - Screenshots save to `screenshots/` directory with timestamps
 - OHLCV capped at 500 bars, trades at 20 per request
 - Pine labels capped at 50 per study by default (pass `max_labels` to override)
+- Pine graphics path for reading custom drawings directly: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`
 
-## Architecture
+## Scope boundaries (see CONTRIBUTING.md)
 
-```
-Claude Code ←→ MCP Server (stdio) ←→ CDP (localhost:9222) ←→ TradingView Desktop (Electron)
-```
-
-Pine graphics path: `study._graphics._primitivesCollection.dwglines.get('lines').get(false)._primitivesDataById`
+This is a **local bridge only**. Changes must not: connect directly to TradingView's servers (everything goes through the local Desktop app via CDP), bypass auth/subscription restrictions, scrape/cache/redistribute market data, add automated trading/order execution, or bundle/reverse-engineer TradingView's proprietary charting code.

--- a/ICT_STRATEGY_SPEC.md
+++ b/ICT_STRATEGY_SPEC.md
@@ -16,13 +16,15 @@ Architecture decision: everything is detected and drawn **natively in Pine Scrip
 
 | Concept | Status | Logic |
 |---|---|---|
-| Trend bias (uptrend/downtrend/range) | ✅ v1 | Compares last two confirmed swing highs/lows (HH/HL = uptrend, LH/LL = downtrend), shown in a top-right table |
+| Trend bias (uptrend/downtrend/range) | ✅ v1, live override v4 (2026-07-15) | Compares last two confirmed swing highs/lows (HH/HL = uptrend, LH/LL = downtrend); a live/unconfirmed BOS (`liveBullBOS`/`liveBearBOS`) now overrides it immediately instead of waiting up to `swingLen` bars for the next confirmed pair, tagged "(live)" in the top-right table until structure confirms it |
 | Break of Structure (BOS) | ✅ v1 | `close` crosses the last confirmed swing high/low |
 | Liquidity sweep | ✅ v1 | Wick trades beyond a swing high/low but closes back inside it; only flags once per level |
 | Fair Value Gap (FVG) | ✅ v1 | Classic 3-candle imbalance (`low > high[2]` / `high < low[2]`); box extends right only while unmitigated, freezes once price trades back through it |
 | Order Block | ✅ v1 (simplified) | Last opposite-colour candle before a BOS impulse, searched back up to `obLookback` bars; box freezes once mitigated (price closes back through it) |
 | Equilibrium / premium-discount | ✅ v1 | 50% midpoint of the current swing range (last swing high ↔ last swing low), with shaded premium/discount zones |
 | Live (unconfirmed) swing high/low + live BOS | ✅ v2 (2026-07-15) | Rolling `ta.highest`/`ta.lowest` over a `swingLen`-derived window — no right-side confirmation bars needed, so it reacts intrabar instead of lagging `swingLen` bars behind the confirmed pivots above. Plotted as dotted yellow/orange circles; a "BOS?" triangle marks when price crosses it live. Toggle via `showLiveSwing` / `showLiveBOS`. |
+| Previous Day/Week High-Low (PDH/PDL/PWH/PWL) | ✅ v3 (2026-07-15) | Non-repainting via `request.security(..., [high[1], low[1]], lookahead=barmerge.lookahead_off)` on `"D"`/`"W"` — always the last *completed* day/week. Silver dashed lines for day, blue dotted for week, each labeled and extending from the start of that day/week to the current bar. Toggle via `showPDHL` / `showPWHL`. |
+| Session highs/lows (Asia/London/NY) | ✅ v3 (2026-07-15) | Tracks the running high/low while each session (`input.session`, default Asia 1900-0400 / London 0300-1200 / NY 0800-1700, all America/New_York) is active; the line freezes and keeps extending right once the session ends, until the next occurrence resets it. Purple/blue/orange lines labeled "ASIA H/L", "LDN H/L", "NY H/L". Toggle via `showSessions`. |
 
 ### Doji patterns (exact set requested, each with its own show/hide input)
 
@@ -48,6 +50,7 @@ Only the exact 8 color/shape combos above are marked (e.g. red dragonfly and gre
 - No alerts wired up for any of these conditions yet
 - Second instrument mentioned early on ("pound is the main one, second is GBP/USD") was clarified to mean GBPUSD is the only instrument for now — revisit if a second pair/cross is actually wanted later
 - Doji thresholds are heuristic defaults — tune `dojiBodyMaxPct` / `oppWickMaxPct` / `longLeggedWickMinPct` / `crossSymTolPct` against real chart examples
+- Session windows (Asia/London/NY) default to commonly-used ET ranges (1900-0400 / 0300-1200 / 0800-1700) — tune via the `showSessions` group's session inputs if Keagan's actual trading hours differ.
 - Confirmed swing/BOS/Order Block structure still has an inherent `swingLen`-bar confirmation lag — `ta.pivothigh`/`ta.pivotlow` need that many bars *after* a pivot to validate it, which is fundamental to what ICT means by a "confirmed" swing, not a bug. The v2 live/unconfirmed layer (see table above) is the workaround for wanting a same-tick reaction; it can relabel which bar was the "swing" as new bars arrive, since it's provisional by design.
 
 ## Real-time behavior (added 2026-07-15)

--- a/ICT_STRATEGY_SPEC.md
+++ b/ICT_STRATEGY_SPEC.md
@@ -22,6 +22,7 @@ Architecture decision: everything is detected and drawn **natively in Pine Scrip
 | Fair Value Gap (FVG) | ✅ v1 | Classic 3-candle imbalance (`low > high[2]` / `high < low[2]`); box extends right only while unmitigated, freezes once price trades back through it |
 | Order Block | ✅ v1 (simplified) | Last opposite-colour candle before a BOS impulse, searched back up to `obLookback` bars; box freezes once mitigated (price closes back through it) |
 | Equilibrium / premium-discount | ✅ v1 | 50% midpoint of the current swing range (last swing high ↔ last swing low), with shaded premium/discount zones |
+| Live (unconfirmed) swing high/low + live BOS | ✅ v2 (2026-07-15) | Rolling `ta.highest`/`ta.lowest` over a `swingLen`-derived window — no right-side confirmation bars needed, so it reacts intrabar instead of lagging `swingLen` bars behind the confirmed pivots above. Plotted as dotted yellow/orange circles; a "BOS?" triangle marks when price crosses it live. Toggle via `showLiveSwing` / `showLiveBOS`. |
 
 ### Doji patterns (exact set requested, each with its own show/hide input)
 
@@ -47,6 +48,13 @@ Only the exact 8 color/shape combos above are marked (e.g. red dragonfly and gre
 - No alerts wired up for any of these conditions yet
 - Second instrument mentioned early on ("pound is the main one, second is GBP/USD") was clarified to mean GBPUSD is the only instrument for now — revisit if a second pair/cross is actually wanted later
 - Doji thresholds are heuristic defaults — tune `dojiBodyMaxPct` / `oppWickMaxPct` / `longLeggedWickMinPct` / `crossSymTolPct` against real chart examples
+- Confirmed swing/BOS/Order Block structure still has an inherent `swingLen`-bar confirmation lag — `ta.pivothigh`/`ta.pivotlow` need that many bars *after* a pivot to validate it, which is fundamental to what ICT means by a "confirmed" swing, not a bug. The v2 live/unconfirmed layer (see table above) is the workaround for wanting a same-tick reaction; it can relabel which bar was the "swing" as new bars arrive, since it's provisional by design.
+
+## Real-time behavior (added 2026-07-15)
+
+- Doji, FVG, and liquidity-sweep detection already react on every realtime tick by default (Pine indicators recalculate the still-forming bar on each price update) — no code gate was holding them to bar-close.
+- Fixed a latent repaint bug: confirmed-BOS and FVG object creation (`line.new`/`box.new`) used live `close`/`high`/`low` inside a one-shot condition with no per-bar guard, so a price chopping back and forth around the level within a single unconfirmed bar could fire the condition on more than one tick and stack duplicate lines/boxes for what should be a single event. Added `bar_index`-based one-shot guards (`lastBullBosBar`/`lastBearBosBar`/`lastBullFvgBar`/`lastBearFvgBar`) — reacts on the first tick the condition trips, never duplicates. Order Block creation is nested under BOS so it inherited the fix for free.
+- Added a genuinely lag-free live swing high/low (rolling `ta.highest`/`ta.lowest`) and a "live BOS" marker built on it, since the confirmed pivots are structurally lagged by `swingLen` bars — see the table above.
 
 ## Next steps (add to as the project grows)
 

--- a/ICT_STRATEGY_SPEC.md
+++ b/ICT_STRATEGY_SPEC.md
@@ -1,0 +1,53 @@
+# ICT Concepts + Doji Scanner — Strategy Spec
+
+Living spec for Keagan's custom GBP/USD chart-analysis project, built on top of this MCP server. Keep this file updated as requirements are added — this is an ongoing, multi-session build.
+
+## Instrument
+
+- Primary chart: **GBPUSD** spot forex. Use `OANDA:GBPUSD` (or another retail forex feed) — do **not** use bare `GBPUSD` or `FX:GBPUSD` in `chart_set_symbol`/`tv symbol --set`, it resolves to `CME_DL:6BU2026` (British Pound *futures*, a different instrument) on this account, likely because of a linked futures broker. Always verify with `tv state` after setting the symbol and confirm the title bar / exchange reads `OANDA` (or your preferred forex broker), not `CME`.
+
+## Implementation
+
+The indicator is developed via the `pine-develop` skill workflow (`node scripts/pine_push.js` / `pine_pull.js`) working out of `scripts/current.pine` (gitignored scratch buffer), and is loaded onto the chart as **"ICT Concepts + Doji Scanner [Keagan]"**. The persisted, version-controlled copy of the source lives at [`indicators/ict-concepts-doji-scanner.pine`](indicators/ict-concepts-doji-scanner.pine) — when you finish an editing session, copy `scripts/current.pine` over that file (`cp scripts/current.pine indicators/ict-concepts-doji-scanner.pine`) so the real deliverable doesn't just live in TradingView's cloud and the gitignored scratch file.
+
+Architecture decision: everything is detected and drawn **natively in Pine Script** (not computed in JS + `draw_shape`), so it redraws live as the chart updates and matches how this repo's other custom indicators already work.
+
+### Structure / ICT concepts (all toggleable via indicator inputs)
+
+| Concept | Status | Logic |
+|---|---|---|
+| Trend bias (uptrend/downtrend/range) | ✅ v1 | Compares last two confirmed swing highs/lows (HH/HL = uptrend, LH/LL = downtrend), shown in a top-right table |
+| Break of Structure (BOS) | ✅ v1 | `close` crosses the last confirmed swing high/low |
+| Liquidity sweep | ✅ v1 | Wick trades beyond a swing high/low but closes back inside it; only flags once per level |
+| Fair Value Gap (FVG) | ✅ v1 | Classic 3-candle imbalance (`low > high[2]` / `high < low[2]`); box extends right only while unmitigated, freezes once price trades back through it |
+| Order Block | ✅ v1 (simplified) | Last opposite-colour candle before a BOS impulse, searched back up to `obLookback` bars; box freezes once mitigated (price closes back through it) |
+| Equilibrium / premium-discount | ✅ v1 | 50% midpoint of the current swing range (last swing high ↔ last swing low), with shaded premium/discount zones |
+
+### Doji patterns (exact set requested, each with its own show/hide input)
+
+| Pattern | Status |
+|---|---|
+| Green Doji | ✅ v1 |
+| Red Doji | ✅ v1 |
+| Green Long-Legged Doji | ✅ v1 |
+| Red Long-Legged Doji | ✅ v1 |
+| Green Cross Doji | ✅ v1 |
+| Red Inverted Cross Doji | ✅ v1 |
+| Green Dragonfly Doji | ✅ v1 |
+| Red Gravestone Doji | ✅ v1 |
+
+Classification is mutually exclusive per candle, checked in priority order: **Dragonfly > Gravestone > Cross (symmetric wicks) > Long-Legged (long but asymmetric wicks) > plain Doji (fallback)**. Thresholds are tunable via inputs (`dojiBodyMaxPct`, `oppWickMaxPct`, `longLeggedWickMinPct`, `crossSymTolPct`) — the defaults are a reasonable starting point, not backtested.
+
+Only the exact 8 color/shape combos above are marked (e.g. red dragonfly and green gravestone are *not* marked) because that's what was asked for. The classification variables already compute the shape for any color, so adding the mirror combos later is a one-line change per pattern if wanted.
+
+## Known caveats / not yet done
+
+- Order Block detection is a simplified heuristic (nearest opposite-colour candle before a BOS), not full ICT nuance (no distinction between breaker blocks, mitigation blocks, propulsion blocks, etc.)
+- No backtesting/statistics on any of these signals yet — purely visual markup
+- No alerts wired up for any of these conditions yet
+- Second instrument mentioned early on ("pound is the main one, second is GBP/USD") was clarified to mean GBPUSD is the only instrument for now — revisit if a second pair/cross is actually wanted later
+- Doji thresholds are heuristic defaults — tune `dojiBodyMaxPct` / `oppWickMaxPct` / `longLeggedWickMinPct` / `crossSymTolPct` against real chart examples
+
+## Next steps (add to as the project grows)
+
+- (add new requirements here as they come up)

--- a/indicators/ict-concepts-doji-scanner.pine
+++ b/indicators/ict-concepts-doji-scanner.pine
@@ -1,0 +1,249 @@
+//@version=6
+indicator("ICT Concepts + Doji Scanner [Keagan]", overlay=true, max_lines_count=500, max_boxes_count=500, max_labels_count=500)
+
+// ============================================================
+// INPUTS
+// ============================================================
+grpStruct = "Structure"
+swingLen        = input.int(5, "Swing Lookback (bars each side)", minval=1, group=grpStruct)
+showBias        = input.bool(true, "Show Bias Table", group=grpStruct)
+showBOS         = input.bool(true, "Show Break of Structure", group=grpStruct)
+showSweep       = input.bool(true, "Show Liquidity Sweeps", group=grpStruct)
+showFVG         = input.bool(true, "Show Fair Value Gaps", group=grpStruct)
+showOB          = input.bool(true, "Show Order Blocks", group=grpStruct)
+showEQ          = input.bool(true, "Show Equilibrium / Premium-Discount", group=grpStruct)
+obLookback      = input.int(20, "Order Block Search Lookback (bars)", minval=1, maxval=50, group=grpStruct)
+
+grpDoji = "Doji Patterns"
+showDoji        = input.bool(true, "Show Green/Red Doji", group=grpDoji)
+showLongLegged  = input.bool(true, "Show Long-Legged Doji", group=grpDoji)
+showCross       = input.bool(true, "Show Cross Doji (green) / Inverted Cross Doji (red)", group=grpDoji)
+showDragonfly   = input.bool(true, "Show Green Dragonfly Doji", group=grpDoji)
+showGravestone  = input.bool(true, "Show Red Gravestone Doji", group=grpDoji)
+dojiBodyMaxPct      = input.float(10.0, "Doji Max Body (% of candle range)", minval=0.1, maxval=50, group=grpDoji) / 100
+oppWickMaxPct       = input.float(10.0, "Dragonfly/Gravestone Max Opposite Wick (% of range)", minval=0, maxval=40, group=grpDoji) / 100
+longLeggedWickMinPct= input.float(35.0, "Long-Legged Min Wick Each Side (% of range)", minval=10, maxval=49, group=grpDoji) / 100
+crossSymTolPct      = input.float(15.0, "Cross Doji Wick Symmetry Tolerance (% of range)", minval=1, maxval=40, group=grpDoji) / 100
+
+// ============================================================
+// STRUCTURE: swing pivots, bias, BOS, liquidity sweeps
+// ============================================================
+ph = ta.pivothigh(high, swingLen, swingLen)
+pl = ta.pivotlow(low, swingLen, swingLen)
+
+var float lastSwingHigh = na
+var float prevSwingHigh = na
+var int   lastSwingHighBar = na
+
+var float lastSwingLow = na
+var float prevSwingLow = na
+var int   lastSwingLowBar = na
+
+if not na(ph)
+    prevSwingHigh := lastSwingHigh
+    lastSwingHigh := ph
+    lastSwingHighBar := bar_index - swingLen
+
+if not na(pl)
+    prevSwingLow := lastSwingLow
+    lastSwingLow := pl
+    lastSwingLowBar := bar_index - swingLen
+
+var string bias = "Range"
+if not na(lastSwingHigh) and not na(prevSwingHigh) and not na(lastSwingLow) and not na(prevSwingLow)
+    if lastSwingHigh > prevSwingHigh and lastSwingLow > prevSwingLow
+        bias := "Uptrend"
+    else if lastSwingHigh < prevSwingHigh and lastSwingLow < prevSwingLow
+        bias := "Downtrend"
+    else
+        bias := "Range"
+
+// Break of Structure
+crossedAboveHigh = ta.crossover(close, lastSwingHigh)
+crossedBelowLow  = ta.crossunder(close, lastSwingLow)
+bullBOS = showBOS and not na(lastSwingHigh) and crossedAboveHigh
+bearBOS = showBOS and not na(lastSwingLow) and crossedBelowLow
+
+if bullBOS
+    line.new(lastSwingHighBar, lastSwingHigh, bar_index, lastSwingHigh, color=color.new(color.lime, 0), style=line.style_solid, width=1)
+    label.new(bar_index, lastSwingHigh, "BOS", style=label.style_label_down, color=color.new(color.lime, 80), textcolor=color.lime, size=size.tiny)
+
+if bearBOS
+    line.new(lastSwingLowBar, lastSwingLow, bar_index, lastSwingLow, color=color.new(color.red, 0), style=line.style_solid, width=1)
+    label.new(bar_index, lastSwingLow, "BOS", style=label.style_label_up, color=color.new(color.red, 80), textcolor=color.red, size=size.tiny)
+
+// Liquidity sweeps — wick beyond a swing level that closes back inside it
+var float lastSweptHigh = na
+var float lastSweptLow = na
+
+sweepHigh = showSweep and not na(lastSwingHigh) and high > lastSwingHigh and close < lastSwingHigh and lastSwingHigh != lastSweptHigh
+sweepLow  = showSweep and not na(lastSwingLow) and low < lastSwingLow and close > lastSwingLow and lastSwingLow != lastSweptLow
+
+if sweepHigh
+    lastSweptHigh := lastSwingHigh
+    label.new(bar_index, high, "Liquidity Sweep", style=label.style_label_down, color=color.new(color.orange, 70), textcolor=color.orange, size=size.tiny)
+
+if sweepLow
+    lastSweptLow := lastSwingLow
+    label.new(bar_index, low, "Liquidity Sweep", style=label.style_label_up, color=color.new(color.orange, 70), textcolor=color.orange, size=size.tiny)
+
+// ============================================================
+// FAIR VALUE GAPS (3-candle imbalance)
+// Boxes extend right only while unmitigated; once price trades back
+// through the gap, the box freezes in place instead of stacking forever.
+// ============================================================
+var box[]   bullFvgBox = array.new_box()
+var float[] bullFvgBot = array.new_float()
+var box[]   bearFvgBox = array.new_box()
+var float[] bearFvgTop = array.new_float()
+
+bullishFVG = showFVG and low > high[2]
+bearishFVG = showFVG and high < low[2]
+
+if bullishFVG
+    b = box.new(bar_index[2], low, bar_index, high[2], border_color=color.new(color.lime, 60), bgcolor=color.new(color.lime, 88))
+    label.new(bar_index[1], (low + high[2]) / 2, "FVG", style=label.style_label_left, color=color.new(color.lime, 100), textcolor=color.lime, size=size.tiny)
+    array.push(bullFvgBox, b)
+    array.push(bullFvgBot, high[2])
+
+if bearishFVG
+    b = box.new(bar_index[2], low[2], bar_index, high, border_color=color.new(color.red, 60), bgcolor=color.new(color.red, 88))
+    label.new(bar_index[1], (low[2] + high) / 2, "FVG", style=label.style_label_left, color=color.new(color.red, 100), textcolor=color.red, size=size.tiny)
+    array.push(bearFvgBox, b)
+    array.push(bearFvgTop, low[2])
+
+if showFVG
+    for j = array.size(bullFvgBox) - 1 to 0
+        bx = array.get(bullFvgBox, j)
+        bot = array.get(bullFvgBot, j)
+        box.set_right(bx, bar_index)
+        if low <= bot
+            array.remove(bullFvgBox, j)
+            array.remove(bullFvgBot, j)
+    for j = array.size(bearFvgBox) - 1 to 0
+        bx = array.get(bearFvgBox, j)
+        top = array.get(bearFvgTop, j)
+        box.set_right(bx, bar_index)
+        if high >= top
+            array.remove(bearFvgBox, j)
+            array.remove(bearFvgTop, j)
+
+// ============================================================
+// ORDER BLOCKS — last opposite-colour candle before a BOS impulse
+// Boxes extend right only while unmitigated (price hasn't closed back through).
+// ============================================================
+var box[]   bullObBox = array.new_box()
+var float[] bullObBot = array.new_float()
+var box[]   bearObBox = array.new_box()
+var float[] bearObTop = array.new_float()
+
+if bullBOS and showOB
+    var bool obFoundUp = false
+    obFoundUp := false
+    for i = 1 to obLookback
+        if not obFoundUp and close[i] < open[i]
+            ob = box.new(bar_index[i], high[i], bar_index, low[i], border_color=color.new(color.teal, 40), bgcolor=color.new(color.teal, 85))
+            label.new(bar_index[i], low[i], "OB", style=label.style_label_up, color=color.new(color.teal, 100), textcolor=color.teal, size=size.tiny)
+            array.push(bullObBox, ob)
+            array.push(bullObBot, low[i])
+            obFoundUp := true
+
+if bearBOS and showOB
+    var bool obFoundDown = false
+    obFoundDown := false
+    for i = 1 to obLookback
+        if not obFoundDown and close[i] > open[i]
+            ob = box.new(bar_index[i], high[i], bar_index, low[i], border_color=color.new(color.maroon, 40), bgcolor=color.new(color.maroon, 85))
+            label.new(bar_index[i], high[i], "OB", style=label.style_label_down, color=color.new(color.maroon, 100), textcolor=color.maroon, size=size.tiny)
+            array.push(bearObBox, ob)
+            array.push(bearObTop, high[i])
+            obFoundDown := true
+
+if showOB
+    for j = array.size(bullObBox) - 1 to 0
+        bx = array.get(bullObBox, j)
+        bot = array.get(bullObBot, j)
+        box.set_right(bx, bar_index)
+        if close < bot
+            array.remove(bullObBox, j)
+            array.remove(bullObBot, j)
+    for j = array.size(bearObBox) - 1 to 0
+        bx = array.get(bearObBox, j)
+        top = array.get(bearObTop, j)
+        box.set_right(bx, bar_index)
+        if close > top
+            array.remove(bearObBox, j)
+            array.remove(bearObTop, j)
+
+// ============================================================
+// EQUILIBRIUM / PREMIUM-DISCOUNT — midpoint of the active swing range
+// ============================================================
+var line eqLine = na
+var box  premiumBox = na
+var box  discountBox = na
+
+rangeValid = showEQ and not na(lastSwingHigh) and not na(lastSwingLow) and lastSwingHigh > lastSwingLow
+if rangeValid
+    eqLevel = (lastSwingHigh + lastSwingLow) / 2
+    leftBar = math.min(lastSwingHighBar, lastSwingLowBar)
+
+    if not na(eqLine)
+        line.delete(eqLine)
+    eqLine := line.new(leftBar, eqLevel, bar_index, eqLevel, color=color.new(color.gray, 30), style=line.style_dashed, width=1)
+
+    if not na(premiumBox)
+        box.delete(premiumBox)
+    premiumBox := box.new(leftBar, lastSwingHigh, bar_index, eqLevel, border_color=na, bgcolor=color.new(color.red, 93))
+
+    if not na(discountBox)
+        box.delete(discountBox)
+    discountBox := box.new(leftBar, eqLevel, bar_index, lastSwingLow, border_color=na, bgcolor=color.new(color.lime, 93))
+
+// ============================================================
+// BIAS TABLE
+// ============================================================
+if showBias and barstate.islast
+    var table biasTable = table.new(position.top_right, 1, 1, border_width=1)
+    biasColor = bias == "Uptrend" ? color.new(color.lime, 70) : bias == "Downtrend" ? color.new(color.red, 70) : color.new(color.gray, 70)
+    table.cell(biasTable, 0, 0, "BIAS: " + bias, text_color=color.white, bgcolor=biasColor)
+
+// ============================================================
+// DOJI PATTERN DETECTION
+// ============================================================
+// Classification is mutually exclusive per candle, checked in this priority:
+// Dragonfly > Gravestone > Cross (symmetric wicks) > Long-Legged (long but asymmetric wicks) > plain Doji (fallback)
+bodyHigh = math.max(open, close)
+bodyLow  = math.min(open, close)
+bodySize = bodyHigh - bodyLow
+candleRange = high - low
+isGreen = close >= open
+isRed   = close < open
+
+bodyPct  = candleRange > 0 ? bodySize / candleRange : 1.0
+upperPct = candleRange > 0 ? (high - bodyHigh) / candleRange : 0.0
+lowerPct = candleRange > 0 ? (bodyLow - low) / candleRange : 0.0
+
+isDojiBase     = candleRange > 0 and bodyPct <= dojiBodyMaxPct
+isDragonfly    = isDojiBase and upperPct <= oppWickMaxPct and lowerPct > oppWickMaxPct
+isGravestone   = isDojiBase and lowerPct <= oppWickMaxPct and upperPct > oppWickMaxPct
+isCross        = isDojiBase and not isDragonfly and not isGravestone and upperPct > oppWickMaxPct and lowerPct > oppWickMaxPct and math.abs(upperPct - lowerPct) <= crossSymTolPct
+isLongLegged   = isDojiBase and not isDragonfly and not isGravestone and not isCross and upperPct >= longLeggedWickMinPct and lowerPct >= longLeggedWickMinPct
+isPlainDoji    = isDojiBase and not isDragonfly and not isGravestone and not isCross and not isLongLegged
+
+markGreenDoji      = showDoji and isPlainDoji and isGreen
+markRedDoji        = showDoji and isPlainDoji and isRed
+markGreenLongLegged= showLongLegged and isLongLegged and isGreen
+markRedLongLegged  = showLongLegged and isLongLegged and isRed
+markGreenCross     = showCross and isCross and isGreen
+markRedCross       = showCross and isCross and isRed
+markGreenDragonfly = showDragonfly and isDragonfly and isGreen
+markRedGravestone  = showGravestone and isGravestone and isRed
+
+plotshape(markGreenDoji,       title="Green Doji",              style=shape.circle,  location=location.belowbar, color=color.lime,   text="D",   textcolor=color.lime,   size=size.tiny)
+plotshape(markRedDoji,         title="Red Doji",                style=shape.circle,  location=location.abovebar, color=color.red,    text="D",   textcolor=color.red,    size=size.tiny)
+plotshape(markGreenLongLegged, title="Green Long-Legged Doji",  style=shape.circle,  location=location.belowbar, color=color.lime,   text="LLD", textcolor=color.lime,   size=size.tiny)
+plotshape(markRedLongLegged,   title="Red Long-Legged Doji",    style=shape.circle,  location=location.abovebar, color=color.red,    text="LLD", textcolor=color.red,    size=size.tiny)
+plotshape(markGreenCross,      title="Green Cross Doji",        style=shape.xcross,  location=location.belowbar, color=color.lime,   text="X",   textcolor=color.lime,   size=size.tiny)
+plotshape(markRedCross,        title="Red Inverted Cross Doji", style=shape.xcross,  location=location.abovebar, color=color.red,    text="X",   textcolor=color.red,    size=size.tiny)
+plotshape(markGreenDragonfly,  title="Green Dragonfly Doji",    style=shape.triangleup,   location=location.belowbar, color=color.aqua,   text="DF",  textcolor=color.aqua,   size=size.tiny)
+plotshape(markRedGravestone,   title="Red Gravestone Doji",     style=shape.triangledown, location=location.abovebar, color=color.fuchsia,text="GS",  textcolor=color.fuchsia,size=size.tiny)

--- a/indicators/ict-concepts-doji-scanner.pine
+++ b/indicators/ict-concepts-doji-scanner.pine
@@ -112,7 +112,7 @@ if bearishFVG
     array.push(bearFvgBox, b)
     array.push(bearFvgTop, low[2])
 
-if showFVG
+if showFVG and array.size(bullFvgBox) > 0
     for j = array.size(bullFvgBox) - 1 to 0
         bx = array.get(bullFvgBox, j)
         bot = array.get(bullFvgBot, j)
@@ -120,6 +120,7 @@ if showFVG
         if low <= bot
             array.remove(bullFvgBox, j)
             array.remove(bullFvgBot, j)
+if showFVG and array.size(bearFvgBox) > 0
     for j = array.size(bearFvgBox) - 1 to 0
         bx = array.get(bearFvgBox, j)
         top = array.get(bearFvgTop, j)
@@ -159,7 +160,7 @@ if bearBOS and showOB
             array.push(bearObTop, high[i])
             obFoundDown := true
 
-if showOB
+if showOB and array.size(bullObBox) > 0
     for j = array.size(bullObBox) - 1 to 0
         bx = array.get(bullObBox, j)
         bot = array.get(bullObBot, j)
@@ -167,6 +168,7 @@ if showOB
         if close < bot
             array.remove(bullObBox, j)
             array.remove(bullObBot, j)
+if showOB and array.size(bearObBox) > 0
     for j = array.size(bearObBox) - 1 to 0
         bx = array.get(bearObBox, j)
         top = array.get(bearObTop, j)

--- a/indicators/ict-concepts-doji-scanner.pine
+++ b/indicators/ict-concepts-doji-scanner.pine
@@ -29,6 +29,14 @@ grpRT = "Real-Time (Unconfirmed)"
 showLiveSwing   = input.bool(true, "Show Live Swing High/Low (no confirmation lag)", group=grpRT)
 showLiveBOS     = input.bool(true, "Show Live BOS (reacts intrabar, unconfirmed)", group=grpRT)
 
+grpSess = "Sessions & Daily/Weekly Levels"
+showPDHL      = input.bool(true, "Show Previous Day High/Low", group=grpSess)
+showPWHL      = input.bool(true, "Show Previous Week High/Low", group=grpSess)
+showSessions  = input.bool(true, "Show Session Highs/Lows (Asia/London/NY)", group=grpSess)
+asiaSession   = input.session("1900-0400", "Asia Session (ET)", group=grpSess)
+londonSession = input.session("0300-1200", "London Session (ET)", group=grpSess)
+nySession     = input.session("0800-1700", "New York Session (ET)", group=grpSess)
+
 // ============================================================
 // STRUCTURE: swing pivots, bias, BOS, liquidity sweeps
 // ============================================================
@@ -71,14 +79,29 @@ liveBearBOS = showLiveBOS and liveCrossDown
 plotshape(liveBullBOS, title="Live BOS Up",   style=shape.triangleup,   location=location.belowbar, color=color.yellow, text="BOS?", textcolor=color.yellow, size=size.tiny)
 plotshape(liveBearBOS, title="Live BOS Down", style=shape.triangledown, location=location.abovebar, color=color.orange, text="BOS?", textcolor=color.orange, size=size.tiny)
 
-var string bias = "Range"
+var string bias     = "Range"
+var bool   biasLive = false
 if not na(lastSwingHigh) and not na(prevSwingHigh) and not na(lastSwingLow) and not na(prevSwingLow)
     if lastSwingHigh > prevSwingHigh and lastSwingLow > prevSwingLow
         bias := "Uptrend"
+        biasLive := false
     else if lastSwingHigh < prevSwingHigh and lastSwingLow < prevSwingLow
         bias := "Downtrend"
+        biasLive := false
     else
         bias := "Range"
+        biasLive := false
+
+// Live override: a live/unconfirmed BOS (see Real-Time group above) flips the
+// bias immediately instead of waiting up to swingLen bars for the next
+// confirmed swing pair — same reactivity as liveBullBOS/liveBearBOS, tagged
+// "(live)" in the table below since it can relabel itself as new bars arrive.
+if liveBullBOS
+    bias := "Uptrend"
+    biasLive := true
+if liveBearBOS
+    bias := "Downtrend"
+    biasLive := true
 
 // Break of Structure
 // bar_index guards below stop this from stacking duplicate lines/labels: since
@@ -242,12 +265,153 @@ if rangeValid
     discountBox := box.new(leftBar, eqLevel, bar_index, lastSwingLow, border_color=na, bgcolor=color.new(color.lime, 93))
 
 // ============================================================
+// PREVIOUS DAY / WEEK HIGH & LOW
+// Non-repainting: request.security with [1] on the daily/weekly series
+// always reads the last *completed* day/week, never the one in progress.
+// ============================================================
+[pdHigh, pdLow] = request.security(syminfo.tickerid, "D", [high[1], low[1]], lookahead=barmerge.lookahead_off)
+[pwHigh, pwLow] = request.security(syminfo.tickerid, "W", [high[1], low[1]], lookahead=barmerge.lookahead_off)
+
+// pdHigh/pwHigh only change value on the first intraday bar of a new day/week
+// (that's when request.security's [1]-lagged daily/weekly series rolls over),
+// so comparing against the previous bar's value doubles as a clean day/week
+// boundary detector for anchoring the line's left edge.
+var int dayStartBar  = na
+var int weekStartBar = na
+if not na(pdHigh) and (na(pdHigh[1]) or pdHigh != pdHigh[1] or pdLow != pdLow[1])
+    dayStartBar := bar_index
+if not na(pwHigh) and (na(pwHigh[1]) or pwHigh != pwHigh[1] or pwLow != pwLow[1])
+    weekStartBar := bar_index
+
+var line pdHighLine = na
+var line pdLowLine  = na
+var line pwHighLine = na
+var line pwLowLine  = na
+var label pdHighLbl = na
+var label pdLowLbl  = na
+var label pwHighLbl = na
+var label pwLowLbl  = na
+
+if showPDHL and not na(pdHigh)
+    if not na(pdHighLine)
+        line.delete(pdHighLine)
+        line.delete(pdLowLine)
+        label.delete(pdHighLbl)
+        label.delete(pdLowLbl)
+    pdHighLine := line.new(dayStartBar, pdHigh, bar_index, pdHigh, color=color.new(color.silver, 20), style=line.style_dashed, width=1)
+    pdLowLine  := line.new(dayStartBar, pdLow,  bar_index, pdLow,  color=color.new(color.silver, 20), style=line.style_dashed, width=1)
+    pdHighLbl  := label.new(bar_index, pdHigh, "PDH", style=label.style_label_left, color=color.new(color.silver, 100), textcolor=color.silver, size=size.tiny)
+    pdLowLbl   := label.new(bar_index, pdLow,  "PDL", style=label.style_label_left, color=color.new(color.silver, 100), textcolor=color.silver, size=size.tiny)
+
+if showPWHL and not na(pwHigh)
+    if not na(pwHighLine)
+        line.delete(pwHighLine)
+        line.delete(pwLowLine)
+        label.delete(pwHighLbl)
+        label.delete(pwLowLbl)
+    pwHighLine := line.new(weekStartBar, pwHigh, bar_index, pwHigh, color=color.new(color.blue, 20), style=line.style_dotted, width=1)
+    pwLowLine  := line.new(weekStartBar, pwLow,  bar_index, pwLow,  color=color.new(color.blue, 20), style=line.style_dotted, width=1)
+    pwHighLbl  := label.new(bar_index, pwHigh, "PWH", style=label.style_label_left, color=color.new(color.blue, 100), textcolor=color.blue, size=size.tiny)
+    pwLowLbl   := label.new(bar_index, pwLow,  "PWL", style=label.style_label_left, color=color.new(color.blue, 100), textcolor=color.blue, size=size.tiny)
+
+// ============================================================
+// SESSION HIGHS/LOWS — Asia, London, New York
+// Each session's H/L line is redrawn every bar, extending right to the
+// current bar; the level itself only updates while that session is active,
+// so once a session ends its line freezes and keeps extending forward as a
+// liquidity reference until the next occurrence of that session resets it.
+// ============================================================
+inAsia   = not na(time(timeframe.period, asiaSession, "America/New_York"))
+inLondon = not na(time(timeframe.period, londonSession, "America/New_York"))
+inNY     = not na(time(timeframe.period, nySession, "America/New_York"))
+
+var float asiaHigh = na
+var float asiaLow  = na
+var int   asiaStartBar = na
+var float londonHigh = na
+var float londonLow  = na
+var int   londonStartBar = na
+var float nyHigh = na
+var float nyLow  = na
+var int   nyStartBar = na
+
+if inAsia and not inAsia[1]
+    asiaHigh := high
+    asiaLow := low
+    asiaStartBar := bar_index
+else if inAsia
+    asiaHigh := math.max(asiaHigh, high)
+    asiaLow := math.min(asiaLow, low)
+
+if inLondon and not inLondon[1]
+    londonHigh := high
+    londonLow := low
+    londonStartBar := bar_index
+else if inLondon
+    londonHigh := math.max(londonHigh, high)
+    londonLow := math.min(londonLow, low)
+
+if inNY and not inNY[1]
+    nyHigh := high
+    nyLow := low
+    nyStartBar := bar_index
+else if inNY
+    nyHigh := math.max(nyHigh, high)
+    nyLow := math.min(nyLow, low)
+
+var line asiaHighLine = na
+var line asiaLowLine  = na
+var line londonHighLine = na
+var line londonLowLine  = na
+var line nyHighLine = na
+var line nyLowLine  = na
+var label asiaHighLbl = na
+var label asiaLowLbl  = na
+var label londonHighLbl = na
+var label londonLowLbl  = na
+var label nyHighLbl = na
+var label nyLowLbl  = na
+
+if showSessions and not na(asiaHigh)
+    if not na(asiaHighLine)
+        line.delete(asiaHighLine)
+        line.delete(asiaLowLine)
+        label.delete(asiaHighLbl)
+        label.delete(asiaLowLbl)
+    asiaHighLine := line.new(asiaStartBar, asiaHigh, bar_index, asiaHigh, color=color.new(color.purple, 30), style=line.style_solid, width=1)
+    asiaLowLine  := line.new(asiaStartBar, asiaLow,  bar_index, asiaLow,  color=color.new(color.purple, 30), style=line.style_solid, width=1)
+    asiaHighLbl  := label.new(bar_index, asiaHigh, "ASIA H", style=label.style_label_left, color=color.new(color.purple, 100), textcolor=color.purple, size=size.tiny)
+    asiaLowLbl   := label.new(bar_index, asiaLow,  "ASIA L", style=label.style_label_left, color=color.new(color.purple, 100), textcolor=color.purple, size=size.tiny)
+
+if showSessions and not na(londonHigh)
+    if not na(londonHighLine)
+        line.delete(londonHighLine)
+        line.delete(londonLowLine)
+        label.delete(londonHighLbl)
+        label.delete(londonLowLbl)
+    londonHighLine := line.new(londonStartBar, londonHigh, bar_index, londonHigh, color=color.new(color.blue, 30), style=line.style_solid, width=1)
+    londonLowLine  := line.new(londonStartBar, londonLow,  bar_index, londonLow,  color=color.new(color.blue, 30), style=line.style_solid, width=1)
+    londonHighLbl  := label.new(bar_index, londonHigh, "LDN H", style=label.style_label_left, color=color.new(color.blue, 100), textcolor=color.blue, size=size.tiny)
+    londonLowLbl   := label.new(bar_index, londonLow,  "LDN L", style=label.style_label_left, color=color.new(color.blue, 100), textcolor=color.blue, size=size.tiny)
+
+if showSessions and not na(nyHigh)
+    if not na(nyHighLine)
+        line.delete(nyHighLine)
+        line.delete(nyLowLine)
+        label.delete(nyHighLbl)
+        label.delete(nyLowLbl)
+    nyHighLine := line.new(nyStartBar, nyHigh, bar_index, nyHigh, color=color.new(color.orange, 30), style=line.style_solid, width=1)
+    nyLowLine  := line.new(nyStartBar, nyLow,  bar_index, nyLow,  color=color.new(color.orange, 30), style=line.style_solid, width=1)
+    nyHighLbl  := label.new(bar_index, nyHigh, "NY H", style=label.style_label_left, color=color.new(color.orange, 100), textcolor=color.orange, size=size.tiny)
+    nyLowLbl   := label.new(bar_index, nyLow,  "NY L", style=label.style_label_left, color=color.new(color.orange, 100), textcolor=color.orange, size=size.tiny)
+
+// ============================================================
 // BIAS TABLE
 // ============================================================
 if showBias and barstate.islast
     var table biasTable = table.new(position.top_right, 1, 1, border_width=1)
     biasColor = bias == "Uptrend" ? color.new(color.lime, 70) : bias == "Downtrend" ? color.new(color.red, 70) : color.new(color.gray, 70)
-    table.cell(biasTable, 0, 0, "BIAS: " + bias, text_color=color.white, bgcolor=biasColor)
+    table.cell(biasTable, 0, 0, "BIAS: " + bias + (biasLive ? " (live)" : ""), text_color=color.white, bgcolor=biasColor)
 
 // ============================================================
 // DOJI PATTERN DETECTION

--- a/indicators/ict-concepts-doji-scanner.pine
+++ b/indicators/ict-concepts-doji-scanner.pine
@@ -25,6 +25,10 @@ oppWickMaxPct       = input.float(10.0, "Dragonfly/Gravestone Max Opposite Wick 
 longLeggedWickMinPct= input.float(35.0, "Long-Legged Min Wick Each Side (% of range)", minval=10, maxval=49, group=grpDoji) / 100
 crossSymTolPct      = input.float(15.0, "Cross Doji Wick Symmetry Tolerance (% of range)", minval=1, maxval=40, group=grpDoji) / 100
 
+grpRT = "Real-Time (Unconfirmed)"
+showLiveSwing   = input.bool(true, "Show Live Swing High/Low (no confirmation lag)", group=grpRT)
+showLiveBOS     = input.bool(true, "Show Live BOS (reacts intrabar, unconfirmed)", group=grpRT)
+
 // ============================================================
 // STRUCTURE: swing pivots, bias, BOS, liquidity sweeps
 // ============================================================
@@ -49,6 +53,24 @@ if not na(pl)
     lastSwingLow := pl
     lastSwingLowBar := bar_index - swingLen
 
+// Live (unconfirmed) swing high/low — a rolling extreme that needs no
+// right-side confirmation bars, so it reacts to price immediately/intrabar
+// instead of lagging swingLen bars behind like the confirmed pivots above.
+rtWindow = swingLen * 2 + 1
+liveSwingHigh = ta.highest(high, rtWindow)
+liveSwingLow  = ta.lowest(low, rtWindow)
+
+plot(showLiveSwing ? liveSwingHigh : na, title="Live Swing High", color=color.new(color.yellow, 55), style=plot.style_circles, linewidth=1)
+plot(showLiveSwing ? liveSwingLow  : na, title="Live Swing Low",  color=color.new(color.orange, 55), style=plot.style_circles, linewidth=1)
+
+liveCrossUp   = ta.crossover(close, liveSwingHigh[1])
+liveCrossDown = ta.crossunder(close, liveSwingLow[1])
+liveBullBOS = showLiveBOS and liveCrossUp
+liveBearBOS = showLiveBOS and liveCrossDown
+
+plotshape(liveBullBOS, title="Live BOS Up",   style=shape.triangleup,   location=location.belowbar, color=color.yellow, text="BOS?", textcolor=color.yellow, size=size.tiny)
+plotshape(liveBearBOS, title="Live BOS Down", style=shape.triangledown, location=location.abovebar, color=color.orange, text="BOS?", textcolor=color.orange, size=size.tiny)
+
 var string bias = "Range"
 if not na(lastSwingHigh) and not na(prevSwingHigh) and not na(lastSwingLow) and not na(prevSwingLow)
     if lastSwingHigh > prevSwingHigh and lastSwingLow > prevSwingLow
@@ -59,16 +81,26 @@ if not na(lastSwingHigh) and not na(prevSwingHigh) and not na(lastSwingLow) and 
         bias := "Range"
 
 // Break of Structure
+// bar_index guards below stop this from stacking duplicate lines/labels: since
+// `close` is the live/still-forming price in real time, ta.crossover can flip
+// true more than once on the same unconfirmed bar as price chops around the
+// level. The guard lets it fire on the first tick that trips it (no waiting
+// for bar close) but only once per bar.
+var int lastBullBosBar = na
+var int lastBearBosBar = na
+
 crossedAboveHigh = ta.crossover(close, lastSwingHigh)
 crossedBelowLow  = ta.crossunder(close, lastSwingLow)
-bullBOS = showBOS and not na(lastSwingHigh) and crossedAboveHigh
-bearBOS = showBOS and not na(lastSwingLow) and crossedBelowLow
+bullBOS = showBOS and not na(lastSwingHigh) and crossedAboveHigh and bar_index != lastBullBosBar
+bearBOS = showBOS and not na(lastSwingLow) and crossedBelowLow and bar_index != lastBearBosBar
 
 if bullBOS
+    lastBullBosBar := bar_index
     line.new(lastSwingHighBar, lastSwingHigh, bar_index, lastSwingHigh, color=color.new(color.lime, 0), style=line.style_solid, width=1)
     label.new(bar_index, lastSwingHigh, "BOS", style=label.style_label_down, color=color.new(color.lime, 80), textcolor=color.lime, size=size.tiny)
 
 if bearBOS
+    lastBearBosBar := bar_index
     line.new(lastSwingLowBar, lastSwingLow, bar_index, lastSwingLow, color=color.new(color.red, 0), style=line.style_solid, width=1)
     label.new(bar_index, lastSwingLow, "BOS", style=label.style_label_up, color=color.new(color.red, 80), textcolor=color.red, size=size.tiny)
 
@@ -97,16 +129,24 @@ var float[] bullFvgBot = array.new_float()
 var box[]   bearFvgBox = array.new_box()
 var float[] bearFvgTop = array.new_float()
 
-bullishFVG = showFVG and low > high[2]
-bearishFVG = showFVG and high < low[2]
+// bar_index guards for the same intrabar-repaint reason as BOS above: `low`/
+// `high` are live on the still-forming bar, so the gap condition could flip
+// true on more than one tick of the same bar without this.
+var int lastBullFvgBar = na
+var int lastBearFvgBar = na
+
+bullishFVG = showFVG and low > high[2] and bar_index != lastBullFvgBar
+bearishFVG = showFVG and high < low[2] and bar_index != lastBearFvgBar
 
 if bullishFVG
+    lastBullFvgBar := bar_index
     b = box.new(bar_index[2], low, bar_index, high[2], border_color=color.new(color.lime, 60), bgcolor=color.new(color.lime, 88))
     label.new(bar_index[1], (low + high[2]) / 2, "FVG", style=label.style_label_left, color=color.new(color.lime, 100), textcolor=color.lime, size=size.tiny)
     array.push(bullFvgBox, b)
     array.push(bullFvgBot, high[2])
 
 if bearishFVG
+    lastBearFvgBar := bar_index
     b = box.new(bar_index[2], low[2], bar_index, high, border_color=color.new(color.red, 60), bgcolor=color.new(color.red, 88))
     label.new(bar_index[1], (low[2] + high) / 2, "FVG", style=label.style_label_left, color=color.new(color.red, 100), textcolor=color.red, size=size.tiny)
     array.push(bearFvgBox, b)

--- a/rules.json
+++ b/rules.json
@@ -1,65 +1,31 @@
 {
-  "watchlist": ["BTCUSDT"],
-  "default_timeframe": "1",
-
-  "strategy": {
-    "name": "10-Second Momentum Scalper",
-    "sources": [
-      "Price momentum — buy if last close > previous close (green candle)",
-      "RSI filter — only trade when RSI is not at an extreme (30–70 range)"
-    ],
-    "primary_timeframes": [
-      "1-minute (signal source)",
-      "10-second execution loop"
-    ]
-  },
-
-  "indicators": {
-    "rsi_14": "Momentum filter. Only trade when RSI is between 30–70 (avoid extremes).",
-    "price_momentum": "Compare last close vs previous close. Up = long signal. Down = short signal."
-  },
+  "watchlist": ["BTCUSD", "ETHUSD", "SOLUSD"],
+  "default_timeframe": "240",
 
   "bias_criteria": {
     "bullish": [
-      "Last 1-min candle closed higher than the one before it",
-      "RSI is between 30 and 70"
+      "Ribbon direction is up (bullish colour)",
+      "Price is above the 20 EMA on the 4H",
+      "RSI is below 60 (room to run)"
     ],
     "bearish": [
-      "Last 1-min candle closed lower than the one before it",
-      "RSI is between 30 and 70"
+      "Ribbon direction is down (bearish colour)",
+      "Price is below the 20 EMA on the 4H",
+      "RSI is above 40 (room to drop)"
     ],
     "neutral": [
-      "RSI is above 70 (overbought — skip)",
-      "RSI is below 30 (oversold — skip)",
-      "Candle close change is less than 0.05% (chop — skip)"
+      "Ribbon is flat or mixed",
+      "Price is chopping around the 20 EMA",
+      "RSI is between 45 and 55"
     ]
   },
-
-  "entry_rules": {
-    "long": [
-      "Last close > previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market buy immediately"
-    ],
-    "short": [
-      "Last close < previous close by at least 0.05%",
-      "RSI between 30 and 70",
-      "Enter market sell immediately"
-    ]
-  },
-
-  "exit_rules": [
-    "Exit automatically after 10 seconds (next loop tick closes previous position)",
-    "No manual exit management — pure time-based scalp"
-  ],
 
   "risk_rules": [
-    "Fixed trade size: 1% of portfolio per trade",
-    "Maximum trade size: $3.00",
-    "Maximum 6 trades per 60-second run",
-    "No stop loss — exit is time-based at next tick",
-    "For demo purposes only — minimum BitGet order size may apply"
+    "Only take trades where R:R is at least 1:2",
+    "No trading in the first 15 minutes of the NY session open",
+    "Maximum 2 open positions at once",
+    "If I have 2 losing trades in a row, stop for the day"
   ],
 
-  "notes": "Demo strategy for YouTube video. Runs 6 trades over 60 seconds, one every 10 seconds. Signal is simple price momentum on 1-min candles with RSI sanity check."
+  "notes": "Add any other context you want Claude to factor in — e.g. macro events this week, key dates, anything that should affect your bias."
 }

--- a/scripts/pine_pull.js
+++ b/scripts/pine_pull.js
@@ -10,7 +10,7 @@ const c = await CDP({ host: 'localhost', port: 9222, target: t.id });
 await c.Runtime.enable();
 
 const src = (await c.Runtime.evaluate({
-  expression: '(function(){var c=document.querySelector(".monaco-editor.pine-editor-monaco");if(!c)return null;var el=c;var fk;for(var i=0;i<20;i++){if(!el)break;fk=Object.keys(el).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;el=el.parentElement}if(!fk)return null;var cur=el[fk];for(var d=0;d<15;d++){if(!cur)break;if(cur.memoizedProps&&cur.memoizedProps.value&&cur.memoizedProps.value.monacoEnv){var env=cur.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0)return eds[0].getValue()}}cur=cur.return}return null})()',
+  expression: '(function(){var els=document.querySelectorAll(".monaco-editor.pine-editor-monaco");for(var idx=0;idx<els.length;idx++){var el=els[idx];var fk;var cur=el;for(var i=0;i<20;i++){if(!cur)break;fk=Object.keys(cur).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;cur=cur.parentElement}if(!fk)continue;var fiber=cur[fk];for(var d=0;d<15;d++){if(!fiber)break;if(fiber.memoizedProps&&fiber.memoizedProps.value&&fiber.memoizedProps.value.monacoEnv){var env=fiber.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0)return eds[0].getValue()}}fiber=fiber.return}}return null})()',
   returnByValue: true,
 })).result?.value;
 

--- a/scripts/pine_push.js
+++ b/scripts/pine_push.js
@@ -12,10 +12,13 @@ if (!t) { console.error('No TradingView target'); process.exit(1); }
 const c = await CDP({ host: 'localhost', port: 9222, target: t.id });
 await c.Runtime.enable();
 
-// Inject source
+// Inject source. There can be multiple .monaco-editor.pine-editor-monaco
+// elements in the DOM (e.g. a stale hidden instance from a previous panel
+// state) — only one has the react fiber env attached, so scan all of them
+// instead of assuming the first querySelector match is live.
 const escaped = JSON.stringify(src);
 const set = (await c.Runtime.evaluate({
-  expression: `(function(){var c=document.querySelector(".monaco-editor.pine-editor-monaco");if(!c)return false;var el=c;var fk;for(var i=0;i<20;i++){if(!el)break;fk=Object.keys(el).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;el=el.parentElement}if(!fk)return false;var cur=el[fk];for(var d=0;d<15;d++){if(!cur)break;if(cur.memoizedProps&&cur.memoizedProps.value&&cur.memoizedProps.value.monacoEnv){var env=cur.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0){eds[0].setValue(${escaped});return true}}}cur=cur.return}return false})()`,
+  expression: `(function(){var els=document.querySelectorAll(".monaco-editor.pine-editor-monaco");for(var idx=0;idx<els.length;idx++){var el=els[idx];var fk;var cur=el;for(var i=0;i<20;i++){if(!cur)break;fk=Object.keys(cur).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;cur=cur.parentElement}if(!fk)continue;var fiber=cur[fk];for(var d=0;d<15;d++){if(!fiber)break;if(fiber.memoizedProps&&fiber.memoizedProps.value&&fiber.memoizedProps.value.monacoEnv){var env=fiber.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0){eds[0].setValue(${escaped});return true}}}fiber=fiber.return}}return false})()`,
   returnByValue: true,
 })).result?.value;
 
@@ -37,7 +40,7 @@ if (!clicked) {
 // Wait then check errors
 await new Promise(r => setTimeout(r, 3000));
 const errors = (await c.Runtime.evaluate({
-  expression: '(function(){var c=document.querySelector(".monaco-editor.pine-editor-monaco");if(!c)return[];var el=c;var fk;for(var i=0;i<20;i++){if(!el)break;fk=Object.keys(el).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;el=el.parentElement}if(!fk)return[];var cur=el[fk];for(var d=0;d<15;d++){if(!cur)break;if(cur.memoizedProps&&cur.memoizedProps.value&&cur.memoizedProps.value.monacoEnv){var env=cur.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0){var model=eds[0].getModel();var markers=env.editor.getModelMarkers({resource:model.uri});return markers.map(function(m){return{line:m.startLineNumber,msg:m.message}})}}}cur=cur.return}return[]})()',
+  expression: '(function(){var els=document.querySelectorAll(".monaco-editor.pine-editor-monaco");for(var idx=0;idx<els.length;idx++){var el=els[idx];var fk;var cur=el;for(var i=0;i<20;i++){if(!cur)break;fk=Object.keys(cur).find(function(k){return k.startsWith("__reactFiber$")});if(fk)break;cur=cur.parentElement}if(!fk)continue;var fiber=cur[fk];for(var d=0;d<15;d++){if(!fiber)break;if(fiber.memoizedProps&&fiber.memoizedProps.value&&fiber.memoizedProps.value.monacoEnv){var env=fiber.memoizedProps.value.monacoEnv;if(env.editor&&typeof env.editor.getEditors==="function"){var eds=env.editor.getEditors();if(eds.length>0){var model=eds[0].getModel();var markers=env.editor.getModelMarkers({resource:model.uri});return markers.map(function(m){return{line:m.startLineNumber,msg:m.message}})}}}fiber=fiber.return}}return[]})()',
   returnByValue: true,
 })).result?.value || [];
 


### PR DESCRIPTION
## Summary
- Bias table now reacts live: a live/unconfirmed BOS (`liveBullBOS`/`liveBearBOS`) flips the displayed bias immediately instead of waiting up to `swingLen` bars for the next confirmed swing pair, tagged "(live)" until confirmed structure catches up.
- Also carries forward this session's prior uncommitted work: Previous Day/Week High-Low (PDH/PDL/PWH/PWL) and Asia/London/NY session high/low levels, both non-repainting and toggleable.
- `ICT_STRATEGY_SPEC.md` updated to reflect all of the above.

## Test plan
- [x] `npm run test:unit` — 29/29 passing
- [ ] Push script to TradingView Pine Editor (`pine-develop` skill) and visually confirm the bias table flips on a live BOS before confirmed structure catches up (needs TradingView Desktop with CDP — not available in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)